### PR TITLE
[FEAT] 전역 예외 처리 및 공통 응답 구조 추가

### DIFF
--- a/src/main/java/com/likelion/zooting/global/exception/GeneralException.java
+++ b/src/main/java/com/likelion/zooting/global/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package com.likelion.zooting.global.exception;
+
+import com.likelion.zooting.global.exception.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException{
+
+    private final BaseErrorCode errorCode;
+
+    public GeneralException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/likelion/zooting/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/zooting/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.likelion.zooting.global.exception;
+
+import com.likelion.zooting.global.exception.code.BaseErrorCode;
+import com.likelion.zooting.global.exception.code.GlobalErrorCode;
+import com.likelion.zooting.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+public class GlobalExceptionHandler {
+
+    // 직접 던진 GeneralException 처리
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
+        BaseErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage(), null));
+    }
+
+    //@Valid 유효성 검사 실패 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        // 에러 메시지 가져오기
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .orElse("잘못된 요청입니다.");
+
+        GlobalErrorCode errorCode = GlobalErrorCode.BAD_REQUEST;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorMessage, null));
+    }
+
+    // 지원하지 않는 HTTP 메서드 호출 처리
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowedException(HttpRequestMethodNotSupportedException e) {
+        GlobalErrorCode errorCode = GlobalErrorCode.METHOD_NOT_ALLOWED;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage(), null));
+    }
+
+    // 그 외 에러 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleAllException(Exception e) {
+        log.error("Unhandled Exception: ", e);
+
+        GlobalErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.failure(errorCode.getCode(), errorCode.getMessage(), null));
+    }
+
+}

--- a/src/main/java/com/likelion/zooting/global/exception/code/BaseErrorCode.java
+++ b/src/main/java/com/likelion/zooting/global/exception/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package com.likelion.zooting.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    String getCode();
+    String getMessage();
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/likelion/zooting/global/exception/code/GlobalErrorCode.java
+++ b/src/main/java/com/likelion/zooting/global/exception/code/GlobalErrorCode.java
@@ -1,0 +1,17 @@
+package com.likelion.zooting.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_405", "지원하지 않는 HTTP 메서드입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/likelion/zooting/global/response/ApiResponse.java
+++ b/src/main/java/com/likelion/zooting/global/response/ApiResponse.java
@@ -1,9 +1,14 @@
 package com.likelion.zooting.global.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 public record ApiResponse<T>(
         boolean isSuccess,
         String code,
         String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         T result
 ) {
     // 데이터가 있는 성공 응답

--- a/src/main/java/com/likelion/zooting/global/response/ApiResponse.java
+++ b/src/main/java/com/likelion/zooting/global/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.likelion.zooting.global.response;
+
+public record ApiResponse<T>(
+        boolean isSuccess,
+        String code,
+        String message,
+        T result
+) {
+    // 데이터가 있는 성공 응답
+    public static <T> ApiResponse<T> success(T result) {
+        return new ApiResponse<>(true, "COMMON_200", "요청에 성공했습니다.", result);
+    }
+    //데이터가 없는 성공 응답 (오버로딩)
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(true, "COMMON_200", "요청에 성공했습니다.", null);
+    }
+    // 실패 시 호출
+    public static <T> ApiResponse<T> failure(String code, String message, T result) {
+        return new ApiResponse<>(false, code, message, result);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
- 없음 (초기 세팅)

---

## 작업 내용

### 1. 전역 예외 처리 구조 추가
- `GlobalExceptionHandler`를 통해 공통 예외 처리 로직 구현
- `GeneralException`, `BaseErrorCode`, `GlobalErrorCode`를 정의하여
  예외를 일관된 형태로 관리하도록 구성

### 2. 공통 API 응답 구조 도입
- `ApiResponse`를 정의하여 모든 API 응답을 표준화
- `isSuccess`, `code`, `message`, `result` 구조로 통일

### 3. JSON 직렬화 정책 적용
- `@JsonPropertyOrder`를 사용하여 응답 필드 순서 고정
- `@JsonInclude(Include.NON_NULL)`을 적용하여 null 필드 제외

---

## 기대 효과
- 예외 처리 로직의 일관성 확보 및 유지보수성 향상
- API 응답 포맷 통일로 프론트엔드와의 협업 효율 증가
- 불필요한 null 데이터 제거로 응답 데이터 최적화