### PR TITLE
[CHORE] Prometheus, Grafana 모니터링 환경 초기 구성

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,12 @@ services:
     container_name: zooting-mysql
     restart: always
     environment:
+      # root 계정 생성
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
+      # user 계정 생성
+      MYSQL_USER: ${SPRING_DATASOURCE_USERNAME}
+      MYSQL_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
       TZ: Asia/Seoul
     ports:
       - "3307:3306"
@@ -33,5 +37,28 @@ services:
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    depends_on:
+      - app
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+
 volumes:
   mysql-data:
+  prometheus_data:
+  grafana_data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+# job과 target 정의
+scrape_configs:
+  - job_name: 'spring-boot'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['app:8080'] # Docker Compose 서비스명 기반 접근

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,3 +24,12 @@ springdoc:
     path: /swagger-ui.html
     operations-sorter: method
     tags-sorter: alpha
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## 연관된 이슈
- #5

---

## 작업 내용
- Spring Boot Actuator endpoint 노출 설정을 추가했습니다.
- Prometheus 메트릭 수집을 위한 scrape 설정 파일을 추가했습니다.
- Docker Compose에 Prometheus, Grafana 서비스를 구성했습니다.

### 1. Actuator endpoint 노출 설정
- `application.yaml`에 `health`, `info`, `prometheus` endpoint 노출 설정을 추가했습니다.
- `/actuator/prometheus`, `/actuator/health` 엔드포인트를 통해 애플리케이션 상태 및 메트릭 확인이 가능하도록 구성했습니다.

### 2. Prometheus, Grafana 연동 환경 구성
- `prometheus.yml` 파일을 추가하여 Spring Boot 애플리케이션의 `/actuator/prometheus` 엔드포인트를 scrape 대상으로 등록했습니다.
- `docker-compose.yaml`에 Prometheus, Grafana 서비스를 추가하여 로컬 환경에서 모니터링 구성이 가능하도록 설정했습니다.

---

## 기대 효과
- 애플리케이션의 메트릭을 Prometheus를 통해 수집할 수 있습니다.
- Grafana를 활용해 JVM, 메모리, CPU, HTTP 요청 등 주요 지표를 시각화할 수 있는 기반이 마련됩니다.
- 추후 모니터링 대시보드 및 알림 설정을 확장하기 쉬운 구조를 갖출 수 있습니다.
