### PR TITLE
[FEAT] Mock API 구현 (프론트 연동 테스트용)

### DIFF
--- a/src/main/java/com/likelion/zooting/global/mock/MockController.java
+++ b/src/main/java/com/likelion/zooting/global/mock/MockController.java
@@ -1,0 +1,50 @@
+package com.likelion.zooting.global.mock;
+
+import com.likelion.zooting.global.response.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 프론트 테스트용 Mock API
+ * 실제 로직 구현 시 삭제 또는 각 도메인으로 이동 필요
+ */
+@RestController
+@RequestMapping("/api")
+public class MockController {
+
+    @PostMapping("/onboarding/instagram")
+    public ApiResponse<Void> verifyInstagram() {
+        return ApiResponse.success();
+    }
+
+    @PostMapping("/onboarding/privacy")
+    public ApiResponse<Void> submitPrivacy() {
+        return ApiResponse.success();
+    }
+
+    @PostMapping("/onboarding/submit")
+    public ApiResponse<Void> submitOnboarding() {
+        return ApiResponse.success();
+    }
+
+    @GetMapping("/profile")
+    public ApiResponse<Map<String, Object>> getProfile() {
+        return ApiResponse.success(Map.of(
+                "profileTag", "감성적인 토끼",
+                "animalType", "RABBIT",
+                "releaseTime", "18:00"
+        ));
+    }
+
+    @PostMapping("/match/result")
+    public ApiResponse<Map<String, Object>> getMatchResult() {
+        return ApiResponse.success(Map.of(
+                "partnerName", "홍길동",
+                "score", 95
+        ));
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
- #12
---

## 작업 내용
- 프론트엔드 API 연동 테스트를 위해 Mock API를 구현했습니다.
- 실제 비즈니스 로직 없이, 명세에 정의된 엔드포인트에 대해 200 OK 및 공통 응답 포맷을 반환하도록 구성했습니다.

### 1. MockController 생성
- `global.mock` 패키지에 `MockController` 추가
- 프론트 테스트용 임시 API로 사용

### 2. 주요 엔드포인트 구현
- POST /onboarding/instagram
- POST /onboarding/privacy
- POST /onboarding/submit
- GET /profile
- POST /match/result

### 3. 공통 응답 포맷 적용
- `ApiResponse`를 사용하여 응답 구조 통일
- 현재는 `result` 없이 성공 응답만 반환

---

## 기대 효과
- 프론트엔드에서 API 연동 및 화면 개발을 선행할 수 있음
- 백엔드 실제 로직 구현 전, API 명세 기반 협업 가능
- 추후 도메인별 Controller로 자연스럽게 확장 가능