### PR TITLE
[FEAT] CORS 설정 추가 (프론트 연동)

### DIFF
--- a/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
@@ -5,6 +5,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -13,6 +18,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
+                // CORS 설정 적용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 기능
                 .formLogin(AbstractHttpConfigurer::disable) // 로그인 ui
                 .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증
@@ -25,5 +32,35 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        /*
+         * 현재는 프론트 연동 테스트 단계이므로 모든 출처 허용
+         *
+         * - 쿠키/세션/인증 정보를 포함한 요청을 허용하려면 "*" 대신 정확한 프론트 주소를 적어야 함
+         */
+        config.setAllowedOrigins(List.of("*"));
+        config.setAllowedMethods(List.of("*"));
+        config.setAllowedHeaders(List.of("*"));
+
+        /*
+         * 현재는 쿠키/세션 인증을 사용하지 않으므로 false
+         *
+         * 나중에 쿠키 기반 인증 또는 credentials 포함 요청을 사용할 경우:
+         * - setAllowedOrigins(List.of("http://localhost:3000"))처럼 명확한 Origin 지정
+         * - setAllowCredentials(true)로 변경
+         */
+        config.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        // 모든 경로에 위 CORS 정책 적용
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
     }
 }


### PR DESCRIPTION
## 연관된 이슈
- #14

---

## 작업 내용
프론트엔드 API 연동을 위해 CORS 설정을 추가했습니다.

### 1. CORS 설정 적용
- Spring Security에 CORS 설정 연결
- 모든 경로(`/**`)에 대해 정책 적용

### 2. 허용 범위 설정
- 모든 Origin 허용
- 모든 HTTP Method 허용
- 모든 Header 허용

### 3. credentials 미사용
- 현재 인증/쿠키를 사용하지 않는 단계이므로 `allowCredentials=false` 설정

---

## 기대 효과
- 프론트엔드에서 CORS 에러 없이 API 호출 가능
- 연동 테스트 및 UI 개발 진행 가능