### PR TITLE
[CHORE] 프론트엔드 배포 주소 CORS 허용 설정

### DIFF
--- a/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
@@ -43,7 +43,12 @@ public class SecurityConfig {
          *
          * - 쿠키/세션/인증 정보를 포함한 요청을 허용하려면 "*" 대신 정확한 프론트 주소를 적어야 함
          */
-        config.setAllowedOrigins(List.of("*"));
+        config.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "https://14th-festival-frontend.vercel.app",
+                "https://zooting.site",
+                "https://www.zooting.site"
+        ));
         config.setAllowedMethods(List.of("*"));
         config.setAllowedHeaders(List.of("*"));
 


### PR DESCRIPTION
## 연관된 이슈

* #16

---

## 작업 내용

### 1. CORS 허용 도메인 설정

* 기존 전체 허용(`*`) 방식 제거
* 프론트엔드 배포 및 로컬 환경 도메인 명시적으로 허용

```java
config.setAllowedOrigins(List.of(
    "http://localhost:3000",
    "https://14th-festival-frontend.vercel.app",
    "https://zooting.site",
    "https://www.zooting.site"
));
```

---

### 2. 브랜치 기준 정정

* 초기 브랜치 생성 시 master 기반으로 생성된 문제 수정
* dev 브랜치를 기준으로 코드 정렬

---

## 변경 이유

* 프론트엔드(Vercel 배포 환경)에서 백엔드 API 호출 시 CORS 에러 발생
* 기존 `*` 설정은 보안상 부적절하며 credentials 사용 시 문제 발생 가능
* 도메인 기반 허용으로 변경하여 안정적인 통신 및 보안 강화

---

## 기대 효과

* Vercel 프론트엔드에서 백엔드 API 정상 호출 가능
* CORS 에러 제거
* 명시적 Origin 허용을 통한 보안성 개선
