### PR TITLE
[FEAT] 개인정보 동의 여부 제출 API 구현

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/user/controller/PrivacyController.java
+++ b/src/main/java/com/likelion/zooting/domain/user/controller/PrivacyController.java
@@ -1,0 +1,38 @@
+package com.likelion.zooting.domain.user.controller;
+
+import com.likelion.zooting.domain.user.dto.PrivacyRequest;
+import com.likelion.zooting.domain.user.service.PrivacyService;
+import com.likelion.zooting.global.exception.GeneralException;
+import com.likelion.zooting.global.exception.code.GlobalErrorCode;
+import com.likelion.zooting.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/onboarding")
+public class PrivacyController implements PrivacyControllerDocs {
+
+    private final PrivacyService privacyService;
+
+    @Override
+    @PostMapping("/privacy")
+    public ResponseEntity<ApiResponse<Void>> submitPrivacyConsent(
+            Authentication authentication,
+            @Valid @RequestBody PrivacyRequest request
+    ) {
+        if (authentication == null) {
+            throw new GeneralException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        String instagramId = authentication.getName();
+        privacyService.submitPrivacyConsent(instagramId, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(null)
+        );
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/user/controller/PrivacyControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/user/controller/PrivacyControllerDocs.java
@@ -1,0 +1,33 @@
+package com.likelion.zooting.domain.user.controller;
+
+import com.likelion.zooting.domain.user.dto.PrivacyRequest;
+import com.likelion.zooting.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface PrivacyControllerDocs {
+
+    @Operation(
+            summary = "개인정보 동의 여부 제출 API",
+            description = """
+                    로그인 후 발급받은 액세스 토큰을 기반으로 현재 사용자를 식별하고,
+                    개인정보 수집 및 이용 동의 여부를 저장합니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "개인정보 동의 여부 저장 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "개인정보 동의 거부"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음")
+    })
+    ResponseEntity<ApiResponse<Void>> submitPrivacyConsent(
+            @Parameter(hidden = true) Authentication authentication,
+            @Parameter(description = "개인정보 동의 여부 요청 정보", required = true)
+            @Valid @RequestBody PrivacyRequest request
+    );
+}

--- a/src/main/java/com/likelion/zooting/domain/user/dto/PrivacyRequest.java
+++ b/src/main/java/com/likelion/zooting/domain/user/dto/PrivacyRequest.java
@@ -1,0 +1,14 @@
+package com.likelion.zooting.domain.user.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+
+public record PrivacyRequest(
+
+        @NotBlank(message = "인스타 ID는 필수입니다.")
+        String instagramId,
+
+        @AssertTrue(message = "개인정보 수집 및 이용 동의는 필수입니다.")
+        Boolean privacyConsent
+) {
+}

--- a/src/main/java/com/likelion/zooting/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/zooting/domain/user/entity/User.java
@@ -45,4 +45,8 @@ public class User {
         this.userPw = userPw;
         this.status = Status.IN_PROGRESS;
     }
+
+    public void updatePrivacyConsent(Boolean privacyConsent) {
+        this.privacyConsent = privacyConsent;
+    }
 }

--- a/src/main/java/com/likelion/zooting/domain/user/mapper/PrivacyMapper.java
+++ b/src/main/java/com/likelion/zooting/domain/user/mapper/PrivacyMapper.java
@@ -1,0 +1,13 @@
+package com.likelion.zooting.domain.user.mapper;
+
+import com.likelion.zooting.domain.user.dto.PrivacyRequest;
+import com.likelion.zooting.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PrivacyMapper {
+
+    public void updatePrivacyConsent(User user, PrivacyRequest request) {
+        user.updatePrivacyConsent(request.privacyConsent());
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/user/service/PrivacyService.java
+++ b/src/main/java/com/likelion/zooting/domain/user/service/PrivacyService.java
@@ -1,0 +1,31 @@
+package com.likelion.zooting.domain.user.service;
+
+import com.likelion.zooting.domain.user.dto.PrivacyRequest;
+import com.likelion.zooting.domain.user.entity.User;
+import com.likelion.zooting.domain.user.exception.UserErrorCode;
+import com.likelion.zooting.domain.user.mapper.PrivacyMapper;
+import com.likelion.zooting.domain.user.repository.UserRepository;
+import com.likelion.zooting.global.exception.GeneralException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PrivacyService {
+
+    private final UserRepository userRepository;
+    private final PrivacyMapper privacyMapper;
+
+    public void submitPrivacyConsent(String instagramId, PrivacyRequest request) {
+        User user = userRepository.findByInstagramId(instagramId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        if (Boolean.FALSE.equals(request.privacyConsent())) {
+            throw new GeneralException(UserErrorCode.PRIVACY_CONSENT_DENIED);
+        }
+
+        privacyMapper.updatePrivacyConsent(user, request);
+    }
+}

--- a/src/main/java/com/likelion/zooting/global/mock/MockController.java
+++ b/src/main/java/com/likelion/zooting/global/mock/MockController.java
@@ -21,10 +21,10 @@ public class MockController {
 //        return ApiResponse.success();
 //    }
 
-    @PostMapping("/onboarding/privacy")
-    public ApiResponse<Void> submitPrivacy() {
-        return ApiResponse.success();
-    }
+//    @PostMapping("/onboarding/privacy")
+//    public ApiResponse<Void> submitPrivacy() {
+//        return ApiResponse.success();
+//    }
 
     @PostMapping("/onboarding/submit")
     public ApiResponse<Void> submitOnboarding() {


### PR DESCRIPTION
## 연관된 이슈
- #24

---

## 작업 내용
- 개인정보 동의 여부 제출 API 구현을 위한 DTO, 문서 인터페이스, 컨트롤러, 서비스, 매퍼 추가
- User 엔티티에 개인정보 동의 여부 저장 로직 반영
- 기존 MockController의 중복 매핑 제거

### 1. 개인정보 동의 요청 DTO 및 문서 인터페이스 추가
- `PrivacyRequest`를 추가하여 인스타 ID와 개인정보 동의 여부를 검증할 수 있도록 구성
- `PrivacyControllerDocs`를 추가하여 Swagger 문서화 내용을 분리

### 2. 개인정보 동의 요청 Controller 추가 및 중복 매핑 제거
- 개인정보 동의 여부를 제출하는 Controller를 추가
- 기존 `MockController`와 충돌하던 매핑을 제거하여 엔드포인트 중복 문제 정리

### 3. 개인정보 동의 저장 로직 구현
- `PrivacyService`, `PrivacyMapper`를 추가하여 개인정보 동의 여부 저장 로직 구현
- `User` 엔티티에 `privacyConsent` 필드 및 수정 메서드 추가
- 개인정보 동의를 거부한 경우 예외가 발생하도록 처리

---

## 기대 효과
- 로그인한 사용자의 개인정보 동의 여부를 실제 사용자 데이터에 반영할 수 있습니다.
- 개인정보 동의 API의 요청/응답 흐름이 명확해지고 문서화가 정리됩니다.
- 기존 Mock API와의 충돌 없이 실제 기능 구현 기반을 마련할 수 있습니다.