### PR TITLE
[FIX] actuator 엔드포인트 접근 허용으로 헬스체크 실패 수정

### DIFF
--- a/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
+                                "/actuator/health",
+                                "/actuator/prometheus",
                                 "/api/onboarding/instagram"
                         ).permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 연관된 이슈
- #24

---

## 작업 내용

- `/actuator/health` 엔드포인트 접근 허용
- `/actuator/prometheus` 엔드포인트 접근 허용
- Spring Security 설정 수정

```java
.requestMatchers(
    "/actuator/health",
    "/actuator/prometheus"
).permitAll()