### PR TITLE
[FIX] 매칭 결과 저장(확정) API 기능 추가  + 수정

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/match/controller/MatchController.java
+++ b/src/main/java/com/likelion/zooting/domain/match/controller/MatchController.java
@@ -50,6 +50,8 @@ public class MatchController implements MatchControllerDocs {
     }
 
     private void isEmptyMatchResult(Integer matchPairCount){
-        throw new GeneralException(MatchErrorCode.NO_MATCHED_USER_CANDIDATES);
+        if(matchPairCount <= 0){
+            throw new GeneralException(MatchErrorCode.NO_MATCHED_USER_CANDIDATES);
+        }
     }
 }

--- a/src/main/java/com/likelion/zooting/domain/match/service/MatchSaveService.java
+++ b/src/main/java/com/likelion/zooting/domain/match/service/MatchSaveService.java
@@ -69,7 +69,7 @@ public class MatchSaveService {    // 이부분 수정(extends)
                                   List<UserMovieGenreMatchCandidate> maleUserMovieGenreMatchCandidates,
                                   List<UserMovieGenreMatchCandidate> femaleUserMovieGenreMatchCandidates) {
         // 이미 한 번 실행한건가?-> DB에 남성 사용자에 대해 저장되어 있는 여부로 확인
-        if (matchRepository.existsByMaleUser_GenderAndMaleUser_Status(Gender.MALE, Status.SUBMITTED)) {
+        if (matchRepository.existsByMaleUser_GenderAndMaleUser_Status(Gender.MALE, Status.MATCHED)) {
             throw new GeneralException(MatchErrorCode.DUPLICATE_EXECUTION_OF_MATCH_SAVE);
         }
 

--- a/src/main/java/com/likelion/zooting/domain/match/service/MatchSaveService.java
+++ b/src/main/java/com/likelion/zooting/domain/match/service/MatchSaveService.java
@@ -5,6 +5,7 @@ import com.likelion.zooting.domain.match.exception.MatchErrorCode;
 import com.likelion.zooting.domain.match.policy.MatchCountPolicy;
 import com.likelion.zooting.domain.match.repository.MatchRepository;
 import com.likelion.zooting.domain.match.service.converter.MatchCandidateConvertorByMap;
+import com.likelion.zooting.domain.match.service.converter.TempMathConverterByMatchedPair;
 import com.likelion.zooting.domain.match.service.data.*;
 import com.likelion.zooting.domain.user.entity.Gender;
 import com.likelion.zooting.domain.user.entity.Status;
@@ -12,7 +13,6 @@ import com.likelion.zooting.domain.user.entity.User;
 import com.likelion.zooting.global.exception.GeneralException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -24,7 +24,7 @@ public class MatchSaveService {    // 이부분 수정(extends)
     private final MatchRepository matchRepository;
     private final MatchCountPolicy matchCountPolicy;
     private final MatchCandidateConvertorByMap matchCandidateConvertorByMap;
-    private Logger log;
+    private final TempMathConverterByMatchedPair tempMathConverterByMatchedPair;
 
     /**
      * 시뮬레이션 결과를 토대로 매칭된 쌍들을 DB에 저장합니다.
@@ -41,6 +41,12 @@ public class MatchSaveService {    // 이부분 수정(extends)
      * <li>생성일자가 아니더라도, 우리가 알 수 있는 값이면 무엇이든 가능하다.</li>
      * </ul>
      *
+     * <p><b>[사용자 상태 전환]</b></p>
+     * <ul>
+     * <li>매칭 성공 : <b>SUBMITTED</b> -> <b>MATCHED</b></li>
+     * <li>매칭 실패에 대해선 이력 관리 부분에서 처리한다.
+     * </ul>
+     *
      * @param finalMatchedPairList                시뮬레이션 결과물(누가 몇 점으로 매칭되었는지만 담고 있다.)
      * @param maleUsers                           남성 사용자
      * @param femaleUsers                         여성 사용자
@@ -50,6 +56,7 @@ public class MatchSaveService {    // 이부분 수정(extends)
      * @param femaleUserInterestMatchCandidates   여성 사용자와 관심사 매칭 후보들
      * @param maleUserMovieGenreMatchCandidates   남성 사용자와 영화 장르 매칭 후보들
      * @param femaleUserMovieGenreMatchCandidates 여성 사용자와 영화 장르 매칭 후보들
+     *
      */
     @Transactional  // -> public써야 한다.
     public void saveResultOfMatch(List<TempMatch> finalMatchedPairList,
@@ -77,11 +84,9 @@ public class MatchSaveService {    // 이부분 수정(extends)
         Map<Long, List<Long>> femaleUserMovieGenreMap = matchCandidateConvertorByMap.movieGenreCandidateToMap(femaleUserMovieGenreMatchCandidates);
 
         List<Matches> pairs = finalMatchedPairList.stream()
-                .map(pair -> new MatchedPair(
-                        maleUsers.get(pair.maleUserIndex()),
-                        femaleUsers.get(pair.femaleUserIndex()),
-                        pair.score()
-                ))
+                .map(pair -> tempMathConverterByMatchedPair.
+                        tempMatchToMatchedPair(pair, maleUsers, femaleUsers)
+                )
                 .map(pair -> Matches.create(
                         pair.maleUser(),
                         pair.femaleUser(),
@@ -98,9 +103,12 @@ public class MatchSaveService {    // 이부분 수정(extends)
                                 femaleUserMovieGenreMap),
                         pair.score()
                 ))
+                .peek(pair -> {
+                    pair.getMaleUser().updateStatus(Status.MATCHED);
+                    pair.getFemaleUser().updateStatus(Status.MATCHED);
+                })
                 .toList();
 
         matchRepository.saveAll(pairs);
     }
-
 }

--- a/src/main/java/com/likelion/zooting/domain/match/service/MatchService.java
+++ b/src/main/java/com/likelion/zooting/domain/match/service/MatchService.java
@@ -123,11 +123,6 @@ public class MatchService {
         // 매칭 (greedy algorithm)
         simulatedMatchResult = matchPolicy.simulateMatching(scoreBoard, indexToMaleUserId, indexToFemaleUserId);
 
-        // 매칭이 하나도 되지 않을 경우
-        if (simulatedMatchResult.finalMatchedPairList().isEmpty()) {
-            throw new GeneralException(MatchErrorCode.NO_MATCHED_USER_CANDIDATES);
-        }
-
         // 만일 매칭 결과 저장할 경우
         if (isSave) {
             matchSaveService.saveResultOfMatch(simulatedMatchResult.finalMatchedPairList(),

--- a/src/main/java/com/likelion/zooting/domain/match/service/converter/TempMathConverterByMatchedPair.java
+++ b/src/main/java/com/likelion/zooting/domain/match/service/converter/TempMathConverterByMatchedPair.java
@@ -1,0 +1,18 @@
+package com.likelion.zooting.domain.match.service.converter;
+
+import com.likelion.zooting.domain.match.service.data.MatchedPair;
+import com.likelion.zooting.domain.match.service.data.TempMatch;
+import com.likelion.zooting.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class TempMathConverterByMatchedPair {
+    public MatchedPair tempMatchToMatchedPair(TempMatch tempMatch, List<User> maleUsers, List<User> femaleUsers){
+        return new MatchedPair(
+                maleUsers.get(tempMatch.maleUserIndex()),
+                femaleUsers.get(tempMatch.femaleUserIndex()),
+                tempMatch.score());
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/zooting/domain/user/entity/User.java
@@ -49,4 +49,8 @@ public class User {
     public void updatePrivacyConsent(Boolean privacyConsent) {
         this.privacyConsent = privacyConsent;
     }
+
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
 }


### PR DESCRIPTION
## 연관된 이슈
- #28 

---

## 작업 내용

### 1. 사용자 상태 변경 로직 추가
- 매칭 저장할 때, 동시에 사용자 상태를 `SUBMITTED`->`MATCHED`로 변경하도록 기능을 추가했습니다.
- 매칭되지 않는 나머지 사용자들은 나중에 이력관리로 dump될 때, `SUBMITTED`->`FAILED`로 변경하도록 추가할 예정입니다.
### 2. 중복 매칭 저장 실행에 대한 오류 수정
- 이전 : 제출된 사용자가 하나라도 있으면 저장 안됨
```java
if (matchRepository.existsByMaleUser_GenderAndMaleUser_Status(Gender.MALE, Status.SUBMITTED)) {
    throw new GeneralException(MatchErrorCode.DUPLICATE_EXECUTION_OF_MATCH_SAVE);
}
```
- 수정 후 : 매칭된 사용자가 하나라도 있으면 저장 안됨
```java
if (matchRepository.existsByMaleUser_GenderAndMaleUser_Status(Gender.MALE, Status.MATCHED)) {
    throw new GeneralException(MatchErrorCode.DUPLICATE_EXECUTION_OF_MATCH_SAVE);
}
```
### 3. 비어있는 매칭 결과에 대한 오류 수정 + (controller에서)하나로 모아 관리하도록 수정
- 기존 : 모든 결과에 대해 무조건 404 에러를 뱉어내게 된다.
```java
private void isEmptyMatchResult(Integer matchPairCount){
    throw new GeneralException(MatchErrorCode.NO_MATCHED_USER_CANDIDATES);
}
```
- 이후 : 매칭된 수가 0이하일 경우에만(조건문 추가) 404 에러를 뱉어내도록 수정했다.
```java
private void isEmptyMatchResult(Integer matchPairCount){
    if(matchPairCount <= 0){
        throw new GeneralException(MatchErrorCode.NO_MATCHED_USER_CANDIDATES);
    }
}
```
- `MatcheService`에 마저 지우지 못한 아래의 코드 삭제 -> controller에서 최종적으로 확인
```java
// 매칭이 하나도 되지 않을 경우
if (simulatedMatchResult.finalMatchedPairList().isEmpty()) {
    throw new GeneralException(MatchErrorCode.NO_MATCHED_USER_CANDIDATES);
}
```
### 4. 테스트 실행
- 이전 미쳐 걸러내지 못한 오류들이 있었기에, 꼼꼼히 테스트를 하기 위해서, `./gradlew clean build -x test`를 통해 캐시와 빌드를 정리하고 다시 테스트를 하였다.
- 시간 검증 로직은 제외하고 실행한 결과이다.
- 코드 : 이전 테스트(#22 ) 코드 수정한 버전입니다.
[test.sql](https://github.com/user-attachments/files/27303156/test.sql)

- test 1. 비어있을 경우
<img width="336" height="100" alt="비어있을 경우" src="https://github.com/user-attachments/assets/97943c76-0b16-4141-8eb2-f639adcb625a" />

- test 2. 성공한 매칭
  - 처음 실행
  <img width="449" height="207" alt="처음 run실행" src="https://github.com/user-attachments/assets/952a5801-f3e8-4e3e-b115-03a32e300b47" />
  - 중복 실행
  <img width="369" height="101" alt="다시 실행했을 때" src="https://github.com/user-attachments/assets/00fac567-3c31-470e-8624-62e675ee6492" />
  - 사용자 상태 변화 확인 -> 제대로 `MATCHED`로 바뀌었음을 알 수 있다.
  <img width="687" height="80" alt="MATCHED상태 변화된 사용자" src="https://github.com/user-attachments/assets/6af55b0f-ad70-4c8e-8693-1b7dfcb87533" />

- test 3. 실패한 매칭
  - 실행 응답
  <img width="340" height="98" alt="실패한 매칭" src="https://github.com/user-attachments/assets/9b35ef49-fa66-41ad-8fe9-57c6895c6a73" />
  - 사용자 상태 변화 확인. -> 변하지 않았다.
  <img width="683" height="84" alt="그대로 남아있는 사용자" src="https://github.com/user-attachments/assets/fce8dc09-90d6-4446-92c5-b2987a8edb5f" />

- test 4. 경쟁구도
  - 처음 실행
  <img width="458" height="212" alt="처음 실행" src="https://github.com/user-attachments/assets/eb0b0393-236d-49fb-8b0f-2eddf334a145" />
  - 중복 실행
  <img width="373" height="106" alt="중복 실행할 경우" src="https://github.com/user-attachments/assets/bd482ce4-67a6-483b-92da-cd06da2dcb6e" />
  - 사용자 상태 변화 확인 -> 매칭된 사용자만 바뀜
  <img width="676" height="110" alt="사용자 상태" src="https://github.com/user-attachments/assets/69257a0a-7e00-4fd7-af57-b124ad666ded" />
  - `Matches`테이블
  <img width="526" height="66" alt="매칭쌍" src="https://github.com/user-attachments/assets/a6426392-20df-4f1d-b6f7-e674eabdf55a" />

---

## 기대 효과
- 사용자 상태 변화 로직로 이력 관리 로직의 기초 기반이 마련되었다.
- 이전 매칭 및 결과 로직에 남아있던 잠재적인 오류를 어느정도 해결했다.

---

## 리뷰 요구사항(선택)
- 앞에서 언급한 바같이, 매칭되지 않는 나머지 사용자들은 나중에 이력 관리 로직에서, `SUBMITTED`->`FAILED`로 변경되는 부분을 구현할 예정입니다.
- 이전에 이러한 에러를 발견 못한 이유 : 도커에서 실행했을때, 테스트를 위해 몇몇 코드를 "주석처리"하고, "클린 빌드"에 대한 처리를 하지 않았기에, 이전 테스트 용으로 남아있던 상태로 실행했기 때문이다.
  - 코드 변경 후 도커에서 실행하기 전 매번 `./gradlew clean build -x test`의 명령을 통해 클린 빌드를 하고 테스트를 했다.
  - 이러한 치명적인 오류를 수정했으니, 작업 실행하기 전 해당 변경사항을 반영한 후 작업했으면 좋겠습니다.