### PR TITLE
[FIX] 개인정보 동의 API 사용자 조회 기준 수정

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/user/controller/PrivacyController.java
+++ b/src/main/java/com/likelion/zooting/domain/user/controller/PrivacyController.java
@@ -28,8 +28,8 @@ public class PrivacyController implements PrivacyControllerDocs {
             throw new GeneralException(GlobalErrorCode.UNAUTHORIZED);
         }
 
-        String instagramId = authentication.getName();
-        privacyService.submitPrivacyConsent(instagramId, request);
+        Long userId = Long.valueOf(authentication.getName());
+        privacyService.submitPrivacyConsent(userId, request);
 
         return ResponseEntity.ok(
                 ApiResponse.success(null)

--- a/src/main/java/com/likelion/zooting/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/user/repository/UserRepository.java
@@ -11,9 +11,6 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User,Long> {
-    Optional<User> findByUserId(Long userId);
-    boolean existsByUserId(Long userId);
-    List<User> findAllByGender(Gender gender);
     List<User> findByGenderAndStatus(Gender gender, Status status);
     Optional<User> findByInstagramId(String instagramId);
 }

--- a/src/main/java/com/likelion/zooting/domain/user/service/PrivacyService.java
+++ b/src/main/java/com/likelion/zooting/domain/user/service/PrivacyService.java
@@ -18,8 +18,8 @@ public class PrivacyService {
     private final UserRepository userRepository;
     private final PrivacyMapper privacyMapper;
 
-    public void submitPrivacyConsent(String instagramId, PrivacyRequest request) {
-        User user = userRepository.findByInstagramId(instagramId)
+    public void submitPrivacyConsent(Long userId, PrivacyRequest request) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         if (Boolean.FALSE.equals(request.privacyConsent())) {


### PR DESCRIPTION
## 연관된 이슈
- #31
---

## 작업 내용

### 1. 개인정보 동의 API 사용자 조회 기준 수정
- JWT 토큰의 subject가 기존 instagramId에서 userId 기준으로 변경됨에 따라, 개인정보 동의 API에서도 인증 정보를 userId로 처리하도록 수정했습니다.
- `Authentication.getName()` 값을 Long 타입의 userId로 변환한 뒤 서비스 계층으로 전달하도록 수정했습니다.

### 2. Service 조회 로직 수정
- 기존 `findByInstagramId()` 조회 방식에서 userId 기반 조회 방식으로 변경했습니다.
- JWT에는 userId가 저장되어 있는데 이를 instagramId로 조회하면서 발생하던 `USER_4041` 오류를 해결했습니다.

### 3. JWT 관련 주석 정리
- 토큰에서 추출하는 사용자 식별값이 instagramId가 아니라 userId임을 명확히 하기 위해 관련 주석을 정리했습니다.

---

## 기대 효과

- 개인정보 동의 API 호출 시, JWT 인증을 통과했음에도 사용자를 찾지 못하던 문제가 해결됩니다.
- JWT 기반 사용자 식별 기준이 userId로 통일되어 인증 이후 사용자 조회 흐름이 더 명확해집니다.
- 이후 다른 인증 필요 API에서도 userId 기준으로 일관성 있게 사용자 정보를 조회할 수 있습니다.