### PR TITLE
[FEAT] 최종 제출 API 저장 로직 완성

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/animaltype/repository/AnimalTypeRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/animaltype/repository/AnimalTypeRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AnimalTypeRepository extends JpaRepository<AnimalType, Long> {
-  Optional<AnimalType> findByAnimalName(String aniamlname);
+  Optional<AnimalType> findByAnimalName(String animalname);
 }

--- a/src/main/java/com/likelion/zooting/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/interest/repository/InterestRepository.java
@@ -3,5 +3,8 @@ package com.likelion.zooting.domain.interest.repository;
 import com.likelion.zooting.domain.interest.entity.Interest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface InterestRepository extends JpaRepository<Interest,Long> {
+  Optional<Interest> findByInterestName(String interestname);
 }

--- a/src/main/java/com/likelion/zooting/domain/moviegenre/repository/MovieGenreRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/moviegenre/repository/MovieGenreRepository.java
@@ -3,5 +3,8 @@ package com.likelion.zooting.domain.moviegenre.repository;
 import com.likelion.zooting.domain.moviegenre.entity.MovieGenre;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MovieGenreRepository extends JpaRepository<MovieGenre,Long> {
+  Optional<MovieGenre> findByMovieGenreName(String movieGenreName);
 }

--- a/src/main/java/com/likelion/zooting/domain/onboarding/Controller/OnboardingController.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/Controller/OnboardingController.java
@@ -16,25 +16,13 @@ public class OnboardingController {
 
   private final OnboardingService onboardingService;
 
-  @PostMapping
+  @PostMapping("/submit")
   public ResponseEntity<ApiResponse<OnboardingResponse>> submit(
       @RequestAttribute Long userId,
       @Valid @RequestBody OnboardingRequest request) {
 
-    // 1. 서비스 로직 수행 (DB 저장)
-    onboardingService.submitOnboarding(userId, request);
-
-    // 2. 성공 응답 객체 생성
-    OnboardingResponse responseData = new OnboardingResponse(true);
-
-    // 3. 작성하신 ApiResponse.success()를 사용하여 최종 반환
-    // 결과 JSON:
-    // {
-    //   "isSuccess": true,
-    //   "code": "COMMON_200",
-    //   "message": "요청에 성공했습니다.",
-    //   "result": { "profileCreated": true }
-    // }
+    // 서비스 로직 수행 (DB 저장) & 성공 응답 객체 생성
+    OnboardingResponse responseData = new OnboardingResponse(onboardingService.submitOnboarding(userId, request));
     return ResponseEntity.ok(ApiResponse.success(responseData));
   }
 }

--- a/src/main/java/com/likelion/zooting/domain/onboarding/dto/OnboardingRequest.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/dto/OnboardingRequest.java
@@ -5,15 +5,15 @@ import java.util.List;
 
 public record OnboardingRequest(
     @NotNull(message = "성별은 필수입니다")
-    @Pattern(regexp = "MALE|FEMALE", message = "성별은 MALE 또는 FEMALE이어야 합니다")
+    @Pattern(regexp = "male|female", message = "성별은 male 또는 female이어야 합니다")
     String gender,
 
     @NotBlank(message = "내 동물상은 필수입니다")
-    String myAnimalType,
+    String animalType,
 
     @NotNull
     @Size(min = 3, max = 3, message = "원하는 상대 동물상은 정확히 3개를 선택해야 합니다")
-    List<String> preferredAnimalTypes,
+    List<String> preferredAnimals,
 
     @NotNull
     @Size(min = 3, max = 3, message = "관심사는 정확히 3개를 선택해야 합니다")

--- a/src/main/java/com/likelion/zooting/domain/onboarding/dto/OnboardingResponse.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/dto/OnboardingResponse.java
@@ -5,5 +5,5 @@ package com.likelion.zooting.domain.onboarding.dto;
  * JSON 예시: { "profileCreated": true }
  */
 public record OnboardingResponse(
-    boolean profileCreated
+    boolean isComplete
 ) {}

--- a/src/main/java/com/likelion/zooting/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/service/OnboardingService.java
@@ -2,9 +2,19 @@ package com.likelion.zooting.domain.onboarding.service;
 
 import com.likelion.zooting.domain.animaltype.entity.AnimalType;
 import com.likelion.zooting.domain.animaltype.repository.AnimalTypeRepository;
+import com.likelion.zooting.domain.interest.entity.Interest;
+import com.likelion.zooting.domain.interest.repository.InterestRepository;
+import com.likelion.zooting.domain.moviegenre.entity.MovieGenre;
+import com.likelion.zooting.domain.moviegenre.repository.MovieGenreRepository;
 import com.likelion.zooting.domain.onboarding.dto.OnboardingRequest;
+import com.likelion.zooting.domain.user.entity.Gender;
+import com.likelion.zooting.domain.user.entity.Status;
 import com.likelion.zooting.domain.user.entity.User;
 import com.likelion.zooting.domain.user.repository.UserRepository;
+import com.likelion.zooting.domain.userinterest.entity.UserInterest;
+import com.likelion.zooting.domain.userinterest.repository.UserInterestRepository;
+import com.likelion.zooting.domain.usermoviegenre.entity.UserMovieGenre;
+import com.likelion.zooting.domain.usermoviegenre.repository.UserMovieGenreRepository;
 import com.likelion.zooting.domain.userpreferredanimaltype.entity.UserPreferredAnimalType;
 import com.likelion.zooting.domain.userpreferredanimaltype.repository.UserPreferredAnimalTypeRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +31,10 @@ public class OnboardingService {
   private final UserRepository userRepository;
   private final AnimalTypeRepository animalTypeRepository;
   private final UserPreferredAnimalTypeRepository preferredAnimalRepository;
+  private final InterestRepository interestRepository;
+  private final UserInterestRepository userInterestRepository;
+  private final MovieGenreRepository movieGenreRepository;
+  private final UserMovieGenreRepository userMovieGenreRepository;
 
   @Transactional
   public boolean submitOnboarding(Long userId, OnboardingRequest request) {
@@ -28,13 +42,25 @@ public class OnboardingService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-    // 2. 선호 동물상 저장
-    // 주의: OnboardingRequest의 필드명이 preferredAnimals인지 preferredAnimalTypes인지 확인하세요.
-    // 만약 에러가 난다면 request.preferredAnimalTypes()로 바꿔야 합니다.
-    List<String> preferredList = request.preferredAnimalTypes();
+    // 2. 상태 검증 - IN_PROGRESS 상태에서만 제출 허용
+    if (user.getStatus() != Status.IN_PROGRESS) {
+      throw new IllegalStateException("이미 온보딩을 완료한 사용자입니다.");
+    }
+
+    // 3. 본인 동물상 조회
+    String myAnimalName = request.animalType();
+
+    AnimalType myAnimal = animalTypeRepository.findByAnimalName(myAnimalName)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동물상: " + myAnimalName));
+
+    // 4. User 정보 업데이트 (성별 + 본인 동물상)
+    user.updateOnboarding(Gender.valueOf(request.gender().toUpperCase()), myAnimal);
+
+    // 5. 선호 동물상 저장
+    List<String> preferredList = request.preferredAnimals();
 
     for (String animalName : preferredList) {
-      // AnimalTypeRepository에 findByName 메서드가 반드시 있어야 합니다!
+
       AnimalType animalType = animalTypeRepository.findByAnimalName(animalName)
           .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동물상: " + animalName));
 
@@ -45,7 +71,42 @@ public class OnboardingService {
       preferredAnimalRepository.save(preferredAnimal);
     }
 
-    // 3. 결과 반환 (Missing return statement 해결)
+    // 6. 관심사 저장
+    List<String> interestList = request.interests();
+
+    for (String interestName : interestList) {
+      String cleanedInterest = interestName.replace("#", "").trim();
+
+      Interest interest = interestRepository.findByInterestName(cleanedInterest)
+          .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관심사: " + interestName));
+
+      // 생성자 호출
+      UserInterest userInterest = new UserInterest(user, interest);
+
+      // 저장
+      userInterestRepository.save(userInterest);
+    }
+
+    // 7. 영화 장르 저장
+    List<String> movieGenreList = request.movieGenres();
+
+    for (String genreName : movieGenreList) {
+      String cleanedGenre = genreName.replace("#", "").trim();
+
+      MovieGenre movieGenre = movieGenreRepository.findByMovieGenreName(cleanedGenre)
+          .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화 장르: " + genreName));
+
+      // 생성자 호출
+      UserMovieGenre userMovieGenre = new UserMovieGenre(user, movieGenre);
+
+      // 저장
+      userMovieGenreRepository.save(userMovieGenre);
+    }
+
+    // 8. 상태 전이 - IN_PROGRESS → SUBMITTED
+    user.markSubmitted();
+
+    // 9. 결과 반환
     return true;
   }
 }

--- a/src/main/java/com/likelion/zooting/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/zooting/domain/user/entity/User.java
@@ -46,6 +46,15 @@ public class User {
         this.status = Status.IN_PROGRESS;
     }
 
+    public void updateOnboarding(Gender gender, AnimalType animalType) {
+        this.gender = gender;
+        this.animalType = animalType;
+    }
+
+    public void markSubmitted() {
+        this.status = Status.SUBMITTED;
+    }
+
     public void updatePrivacyConsent(Boolean privacyConsent) {
         this.privacyConsent = privacyConsent;
     }

--- a/src/main/java/com/likelion/zooting/domain/userinterest/entity/UserInterest.java
+++ b/src/main/java/com/likelion/zooting/domain/userinterest/entity/UserInterest.java
@@ -22,4 +22,9 @@ public class UserInterest {
     @ManyToOne(fetch = FetchType.LAZY)  // 최적화를 위해 INTEREST를 DB에서 가져오지 않도록 설정
     @JoinColumn(name = "INTEREST_ID")   // 외래키 설정
     private Interest interest;  // DB로 저장될 땐 PK로 저장되지만, Entity로 가져오므로 interest로 지었다.
+
+    public UserInterest(User user, Interest interest) {
+        this.user = user;
+        this.interest = interest;
+    }
 }

--- a/src/main/java/com/likelion/zooting/domain/usermoviegenre/entity/UserMovieGenre.java
+++ b/src/main/java/com/likelion/zooting/domain/usermoviegenre/entity/UserMovieGenre.java
@@ -22,4 +22,9 @@ public class UserMovieGenre {
     @ManyToOne(fetch = FetchType.LAZY)  // 최적화를 위해 MOVIE_GENRE를 DB에서 가져오지 않도록 설정
     @JoinColumn(name = "MOVIE_GENRE_ID")    // 외래키 설정
     private MovieGenre movieGenre;  // DB로 저장될 땐 PK로 저장되지만, Entity로 가져오므로 user로 지었다.
+
+    public UserMovieGenre(User user, MovieGenre movieGenre) {
+        this.user = user;
+        this.movieGenre = movieGenre;
+    }
 }

--- a/src/main/java/com/likelion/zooting/global/mock/MockController.java
+++ b/src/main/java/com/likelion/zooting/global/mock/MockController.java
@@ -26,10 +26,10 @@ public class MockController {
 //        return ApiResponse.success();
 //    }
 
-    @PostMapping("/onboarding/submit")
-    public ApiResponse<Void> submitOnboarding() {
-        return ApiResponse.success();
-    }
+//    @PostMapping("/onboarding/submit")
+//    public ApiResponse<Void> submitOnboarding() {
+//        return ApiResponse.success();
+//    }
 
     @GetMapping("/profile")
     public ApiResponse<Map<String, Object>> getProfile() {


### PR DESCRIPTION
## 연관된 이슈
- #18 

---

## 작업 내용
온보딩 최종 제출 API의 저장 로직을 완성하고, 데이터가 정상적으로 DB에 반영되도록 전체 흐름을 수정했습니다.  
또한 테이블 매핑 오류와 API 경로 충돌 문제를 함께 해결했습니다.

### 1. 온보딩 제출 로직 구현
- OnboardingService에 최종 제출 로직 구현
- 유저 상태 검증 (IN_PROGRESS → SUBMITTED)
- 본인 동물상, 선호 동물상, 관심사, 영화 장르 저장 로직 추가
- 연관 엔티티(UserInterest, UserMovieGenre 등) 생성 및 저장 처리

### 2. DB 매핑 및 데이터 저장 문제 해결
- 테이블에 값이 저장되지 않던 문제 수정
- Entity 간 연관관계 및 Repository 로직 점검 및 수정
- 잘못된 필드명 및 매핑 오류 수정

### 3. API 경로 충돌 해결
- MockController와 실제 Controller 간 URL 충돌 문제 해결
- 중복된 API 경로 수정 및 테스트용 API 정리

### 4. 기타 수정 사항
- DTO(OnboardingRequest, OnboardingResponse) 구조 보완
- User 엔티티 상태 변경 로직 추가
- 코드 전반 리팩토링 및 정리

---

## 기대 효과
- 온보딩 데이터가 정상적으로 DB에 저장됨
- API 호출 시 에러 없이 안정적으로 동작
- 컨트롤러 간 URL 충돌 방지로 유지보수성 향상
- 사용자 온보딩 흐름이 완전하게 동작 가능