### PR TITLE
[CHORE] Node Exporter 기반 서버 리소스 모니터링 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,23 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
 
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    pid: host
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    expose:
+      - "9100"
+
 volumes:
   mysql-data:
   prometheus_data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -7,3 +7,7 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['app:8080'] # Docker Compose 서비스명 기반 접근
+
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets: [ 'node-exporter:9100' ]


### PR DESCRIPTION
## 연관된 이슈
- #30

---

## 작업 내용
기존 Prometheus, Grafana 모니터링 환경에 Node Exporter를 추가하여 EC2 서버 리소스 지표까지 함께 수집할 수 있도록 설정했습니다.

기존에 Grafana 대시보드에서는 Spring Boot 애플리케이션의 주요 지표를 확인할 수 있도록 구성되어 있었습니다.

- 애플리케이션 UP/DOWN 상태
- API 요청 수
- HTTP 상태 코드별 응답 수
- API 응답 시간
- JVM 메모리 사용량
- JVM 스레드 수
- GC 발생 횟수 및 소요 시간
- HikariCP DB 커넥션 상태

이번 PR에서는 여기에 서버 리소스 모니터링을 추가했습니다.

### 1. Node Exporter 서비스 추가

`docker-compose.yml`에 Node Exporter 서비스를 추가했습니다.

이를 통해 EC2 서버의 CPU, 메모리, 디스크, 네트워크 등 서버 리소스 지표를 수집할 수 있도록 구성했습니다.

또한 Node Exporter의 `9100` 포트는 외부에 직접 노출하지 않고, Docker Compose 내부 네트워크에서 Prometheus가 접근하도록 설정했습니다.

### 2. Prometheus scrape 설정 추가

`prometheus.yml`에 Node Exporter scrape job을 추가했습니다.

Prometheus가 `node-exporter:9100`을 대상으로 서버 리소스 메트릭을 주기적으로 수집할 수 있도록 설정했습니다.

---

## 기대 효과

- Grafana에서 Spring Boot 애플리케이션 지표와 EC2 서버 리소스 지표를 함께 확인할 수 있습니다.
- CPU, 메모리, 디스크, 네트워크 사용량을 확인하여 서버 부하나 리소스 부족 상황을 조기에 파악할 수 있습니다.
- 애플리케이션 장애 발생 시 API, JVM, DB 커넥션 지표와 서버 리소스 지표를 함께 비교하여 원인 분석에 활용할 수 있습니다.
- Node Exporter 포트를 외부에 직접 노출하지 않아 불필요한 외부 접근을 줄일 수 있습니다.
