### PR TITLE
[FEAT] 일일 운영 데이터 초기화 스케줄링 기능 구현

### DIFF
--- a/src/main/java/com/likelion/zooting/ZootingApplication.java
+++ b/src/main/java/com/likelion/zooting/ZootingApplication.java
@@ -2,7 +2,9 @@ package com.likelion.zooting;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ZootingApplication {
 

--- a/src/main/java/com/likelion/zooting/domain/dailyreset/controller/DailyResetController.java
+++ b/src/main/java/com/likelion/zooting/domain/dailyreset/controller/DailyResetController.java
@@ -1,0 +1,23 @@
+package com.likelion.zooting.domain.dailyreset.controller;
+
+import com.likelion.zooting.domain.dailyreset.dto.DailyResetResponse;
+import com.likelion.zooting.domain.dailyreset.service.DailyResetService;
+import com.likelion.zooting.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/internal/daily-reset")
+public class DailyResetController implements DailyResetControllerDocs {
+
+    private final DailyResetService dailyResetService;
+
+    @DeleteMapping
+    public ApiResponse<DailyResetResponse> resetDailyData() {
+        DailyResetResponse response = dailyResetService.resetDailyData();
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/dailyreset/controller/DailyResetControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/dailyreset/controller/DailyResetControllerDocs.java
@@ -1,0 +1,40 @@
+package com.likelion.zooting.domain.dailyreset.controller;
+
+import com.likelion.zooting.domain.dailyreset.dto.DailyResetResponse;
+import com.likelion.zooting.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Daily Reset", description = "일일 운영 데이터 초기화 API")
+public interface DailyResetControllerDocs {
+
+    @Operation(
+            summary = "일일 데이터 초기화",
+            description = """
+                    매일 낮 10시 59분 59초에 자동 실행되는 일일 운영 데이터 초기화 API입니다.
+                    
+                    본 API는 수동 초기화 테스트 및 내부 운영 용도로 사용됩니다.
+                    
+                    삭제 대상:
+                    - 매칭 결과 데이터
+                    - 사용자 관심사 데이터
+                    - 사용자 영화 장르 데이터
+                    - 사용자 선호 동물상 데이터
+                    - 사용자 데이터
+                    
+                    이력 테이블 저장은 별도 기능에서 처리되며,
+                    본 API는 메인 테이블의 데이터 삭제만 수행합니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일일 데이터 초기화 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "초기화할 매칭 결과가 없는 경우"
+            )
+    })
+    ApiResponse<DailyResetResponse> resetDailyData();
+}

--- a/src/main/java/com/likelion/zooting/domain/dailyreset/dto/DailyResetResponse.java
+++ b/src/main/java/com/likelion/zooting/domain/dailyreset/dto/DailyResetResponse.java
@@ -1,0 +1,14 @@
+package com.likelion.zooting.domain.dailyreset.dto;
+
+import java.time.LocalDateTime;
+
+public record DailyResetResponse(
+        boolean isDeleted,
+        LocalDateTime deletedAt,
+        long deletedMatchCount,
+        long deletedUserInterestCount,
+        long deletedUserMovieGenreCount,
+        long deletedUserPreferredAnimalTypeCount,
+        long deletedUserCount
+) {
+}

--- a/src/main/java/com/likelion/zooting/domain/dailyreset/exception/DailyResetErrorCode.java
+++ b/src/main/java/com/likelion/zooting/domain/dailyreset/exception/DailyResetErrorCode.java
@@ -1,0 +1,34 @@
+package com.likelion.zooting.domain.dailyreset.exception;
+
+import com.likelion.zooting.global.exception.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum DailyResetErrorCode implements BaseErrorCode {
+
+    DAILY_RESET_DATA_NOT_FOUND("DAILY_RESET_4041", "초기화할 일일 운영 데이터가 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    DailyResetErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/dailyreset/scheduler/DailyResetScheduler.java
+++ b/src/main/java/com/likelion/zooting/domain/dailyreset/scheduler/DailyResetScheduler.java
@@ -1,0 +1,34 @@
+package com.likelion.zooting.domain.dailyreset.scheduler;
+
+import com.likelion.zooting.domain.dailyreset.dto.DailyResetResponse;
+import com.likelion.zooting.domain.dailyreset.service.DailyResetService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyResetScheduler {
+
+    private final DailyResetService dailyResetService;
+
+    @Scheduled(cron = "59 59 10 * * *", zone = "Asia/Seoul")
+    public void resetDailyData() {
+        log.info("[DailyResetScheduler] 일일 데이터 초기화를 시작합니다.");
+
+        DailyResetResponse response = dailyResetService.resetDailyData();
+
+        log.info(
+                "[DailyResetScheduler] 일일 데이터 초기화 완료 - isDeleted: {}, deletedAt: {}, match: {}, userInterest: {}, userMovieGenre: {}, userPreferredAnimalType: {}, user: {}",
+                response.isDeleted(),
+                response.deletedAt(),
+                response.deletedMatchCount(),
+                response.deletedUserInterestCount(),
+                response.deletedUserMovieGenreCount(),
+                response.deletedUserPreferredAnimalTypeCount(),
+                response.deletedUserCount()
+        );
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/dailyreset/service/DailyResetService.java
+++ b/src/main/java/com/likelion/zooting/domain/dailyreset/service/DailyResetService.java
@@ -1,0 +1,63 @@
+package com.likelion.zooting.domain.dailyreset.service;
+
+import com.likelion.zooting.domain.dailyreset.dto.DailyResetResponse;
+import com.likelion.zooting.domain.dailyreset.exception.DailyResetErrorCode;
+import com.likelion.zooting.domain.match.exception.MatchErrorCode;
+import com.likelion.zooting.domain.match.repository.MatchRepository;
+import com.likelion.zooting.domain.user.repository.UserRepository;
+import com.likelion.zooting.domain.userinterest.repository.UserInterestRepository;
+import com.likelion.zooting.domain.usermoviegenre.repository.UserMovieGenreRepository;
+import com.likelion.zooting.domain.userpreferredanimaltype.repository.UserPreferredAnimalTypeRepository;
+import com.likelion.zooting.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class DailyResetService {
+
+    private final MatchRepository matchRepository;
+    private final UserInterestRepository userInterestRepository;
+    private final UserMovieGenreRepository userMovieGenreRepository;
+    private final UserPreferredAnimalTypeRepository userPreferredAnimalTypeRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public DailyResetResponse resetDailyData() {
+        long matchCount = matchRepository.count();
+        long userInterestCount = userInterestRepository.count();
+        long userMovieGenreCount = userMovieGenreRepository.count();
+        long userPreferredAnimalTypeCount = userPreferredAnimalTypeRepository.count();
+        long userCount = userRepository.count();
+
+        if (matchCount == 0
+                && userInterestCount == 0
+                && userMovieGenreCount == 0
+                && userPreferredAnimalTypeCount == 0
+                && userCount == 0) {
+            throw new GeneralException(DailyResetErrorCode.DAILY_RESET_DATA_NOT_FOUND);
+        }
+
+        // FK 제약 조건을 고려하여 User를 참조하는 테이블부터 삭제
+        matchRepository.deleteAllInBatch();
+
+        userInterestRepository.deleteAllInBatch();
+        userMovieGenreRepository.deleteAllInBatch();
+        userPreferredAnimalTypeRepository.deleteAllInBatch();
+
+        userRepository.deleteAllInBatch();
+
+        return new DailyResetResponse(
+                true,
+                LocalDateTime.now(),
+                matchCount,
+                userInterestCount,
+                userMovieGenreCount,
+                userPreferredAnimalTypeCount,
+                userCount
+        );
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/zooting/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.likelion.zooting.domain.user.entity;
 import com.likelion.zooting.domain.animaltype.entity.AnimalType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -34,6 +35,7 @@ public class User {
     @Column(name = "STATUS", length = 10)
     private Status status;  // 처리 상태
 
+    @CreationTimestamp
     @Column(name = "CREATED_AT", updatable = false) // 수정 못하게 설정
     private LocalDateTime createdAt;    // 생성 시간
 

--- a/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/actuator/health",
                                 "/actuator/prometheus",
-                                "/api/onboarding/instagram"
+                                "/api/onboarding/instagram",
+                                "/api/internal/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 연관된 이슈
- #36

---

## 작업 내용
매일 낮 10시 59분 59초에 일일 운영 데이터를 초기화하는 기능을 구현하였습니다.

기존에는 “매칭 결과 초기화” 기능으로 논의되었지만, 실제 삭제 대상이 `Match` 테이블뿐 아니라 `User`, `UserInterest`, `UserMovieGenre`, `UserPreferredAnimalType`까지 포함되므로 `dailyreset` 도메인으로 분리하여 구현하였습니다.

### 1. 일일 운영 데이터 초기화 로직 구현

- `dailyreset` 도메인 패키지를 새로 생성하였습니다.
- 일일 운영 데이터 삭제를 담당하는 `DailyResetService`를 구현하였습니다.
- FK 제약 조건을 고려하여 `User`를 참조하는 테이블을 먼저 삭제한 뒤, 마지막에 `User` 데이터를 삭제하도록 처리하였습니다.
- 초기화할 데이터가 없는 경우 `DailyResetErrorCode`를 통해 예외를 반환하도록 구현하였습니다.
- 삭제 결과 응답을 위한 `DailyResetResponse`를 추가하였습니다.

### 2. 일일 운영 데이터 초기화 API 및 Swagger 문서 추가

- 내부 운영용 초기화 API를 추가하였습니다.

`DELETE /api/internal/daily-reset`

- `DailyResetControllerDocs`를 통해 Swagger 문서를 분리 작성하였습니다.
- 초기화 성공 응답과 초기화 대상 데이터가 없는 경우의 예외 응답을 문서화하였습니다.

### 3. 일일 운영 데이터 초기화 스케줄러 구현

- `DailyResetScheduler`를 추가하여 매일 낮 10시 59분 59초에 초기화 로직이 자동 실행되도록 구현하였습니다.

`@Scheduled(cron = "59 59 10 * * *", zone = "Asia/Seoul")`

- 스케줄링 기능 사용을 위해 `ZootingApplication`에 `@EnableScheduling`을 추가하였습니다.
- 초기화 시작 및 완료 시 로그를 남기도록 처리하였습니다.

### 4. 내부 API 접근 제어 및 CORS 정책 수정

- 내부 API 경로 접근 제어를 위해 `SecurityConfig` 설정을 수정하였습니다.
- 배포 환경에서 필요한 CORS 허용 정책을 함께 수정하였습니다.

### 5. 사용자 생성 시간 저장 필드 추가

- 최초 로그인 시 생성되는 `User` 데이터에 생성 시간이 저장되도록 `createdAt` 필드를 추가하였습니다.
- 해당 변경은 이력 테이블 저장 및 일일 운영 데이터 기준 확인에 활용될 수 있는 부수 작업입니다.

---

## 기대 효과

- 매일 운영 시간이 지난 뒤 메인 테이블의 데이터를 자동으로 초기화할 수 있습니다.
- `User`, `Match` 및 사용자 선택 정보 테이블에 당일 운영 데이터만 유지할 수 있습니다.
- 이력 테이블 저장 기능과 분리하여, 초기화 책임을 명확히 분리할 수 있습니다.
- 수동 초기화 API를 통해 개발 및 운영 중 초기화 동작을 확인할 수 있습니다.
- `createdAt` 저장을 통해 사용자 데이터 생성 시점을 명확히 추적할 수 있습니다.