### PR TITLE
[REFACTOR] Match, History 도메인 엔드포인트 정의 위치 이전 (Docs → Controller) 

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/animaltype/service/converter/AnimalTypeIdToName.java
+++ b/src/main/java/com/likelion/zooting/domain/animaltype/service/converter/AnimalTypeIdToName.java
@@ -1,0 +1,19 @@
+package com.likelion.zooting.domain.animaltype.service.converter;
+
+import com.likelion.zooting.domain.animaltype.entity.AnimalType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class AnimalTypeIdToName {
+    public Map<Long, String> animalTypesToNames(List<AnimalType> animalTypes) {
+        return animalTypes.stream()
+                .collect(Collectors.toMap(
+                        AnimalType::getAnimalTypeId,
+                        AnimalType::getAnimalName
+                ));
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/likelion/zooting/domain/history/controller/HistoryController.java
@@ -1,0 +1,31 @@
+package com.likelion.zooting.domain.history.controller;
+
+import com.likelion.zooting.domain.history.dto.HistoryResponse;
+import com.likelion.zooting.domain.history.exception.HistoryErrorCode;
+import com.likelion.zooting.domain.history.sevice.HistoryService;
+import com.likelion.zooting.global.exception.GeneralException;
+import com.likelion.zooting.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/internal/history")
+public class HistoryController implements HistoryControllerDocs {
+    private final HistoryService historyService;
+    @Override
+    public ResponseEntity<ApiResponse<HistoryResponse>> createHistories() {
+        HistoryResponse historyResponse = historyService.createHistories();
+        // 1. 유저 데이터가 시스템에 아예 없는 경우 (404)
+        if(historyResponse.totalUserCount() <= 0){
+            throw new GeneralException(HistoryErrorCode.NO_USER_FOR_CREATE_HISTORY);
+        }
+        // 2. 매칭 결과(Matches)가 없어 이력이 생성되지 않은 경우 (403)
+        if(historyResponse.matchedUserCount() <= 0){
+            throw new GeneralException(HistoryErrorCode.BEFORE_EXECUTE_MATCH_SAVED);
+        }
+        return ResponseEntity.ok(ApiResponse.success(historyResponse));
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/likelion/zooting/domain/history/controller/HistoryController.java
@@ -22,8 +22,11 @@ public class HistoryController implements HistoryControllerDocs {
         if(historyResponse.totalUserCount() <= 0){
             throw new GeneralException(HistoryErrorCode.NO_USER_FOR_CREATE_HISTORY);
         }
+        int actualProcessedCount = historyResponse.matchedUserCount() +
+                historyResponse.unmatchedUserCount() +
+                historyResponse.erredUserCount();
         // 2. 매칭 결과(Matches)가 없어 이력이 생성되지 않은 경우 (403)
-        if(historyResponse.matchedUserCount() <= 0){
+        if(actualProcessedCount <= 0){
             throw new GeneralException(HistoryErrorCode.BEFORE_EXECUTE_MATCH_SAVED);
         }
         return ResponseEntity.ok(ApiResponse.success(historyResponse));

--- a/src/main/java/com/likelion/zooting/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/likelion/zooting/domain/history/controller/HistoryController.java
@@ -7,6 +7,7 @@ import com.likelion.zooting.global.exception.GeneralException;
 import com.likelion.zooting.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/internal/history")
 public class HistoryController implements HistoryControllerDocs {
     private final HistoryService historyService;
+
     @Override
+    @PostMapping("/create")
     public ResponseEntity<ApiResponse<HistoryResponse>> createHistories() {
         HistoryResponse historyResponse = historyService.createHistories();
         // 1. 유저 데이터가 시스템에 아예 없는 경우 (404)

--- a/src/main/java/com/likelion/zooting/domain/history/controller/HistoryControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/history/controller/HistoryControllerDocs.java
@@ -27,7 +27,7 @@ public interface HistoryControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "403",
-                    description = "매칭 저장 미실행",
+                    description = "생성할 이력이 없습니다.",
                     content = @Content(schema = @Schema(implementation = com.likelion.zooting.global.response.ApiResponse.class))
             ),
             @ApiResponse(

--- a/src/main/java/com/likelion/zooting/domain/history/controller/HistoryControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/history/controller/HistoryControllerDocs.java
@@ -8,11 +8,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "History", description = "이력 관리 관련 API")
-@RequestMapping("/api/internal/history")
 public interface HistoryControllerDocs {
 
     @Operation(
@@ -36,6 +33,5 @@ public interface HistoryControllerDocs {
                     content = @Content(schema = @Schema(implementation = com.likelion.zooting.global.response.ApiResponse.class))
             )
     })
-    @PostMapping("/create")
     ResponseEntity<com.likelion.zooting.global.response.ApiResponse<HistoryResponse>> createHistories();
 }

--- a/src/main/java/com/likelion/zooting/domain/history/controller/HistoryControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/history/controller/HistoryControllerDocs.java
@@ -1,0 +1,41 @@
+package com.likelion.zooting.domain.history.controller;
+
+import com.likelion.zooting.domain.history.dto.HistoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "History", description = "이력 관리 관련 API")
+@RequestMapping("/api/internal/history")
+public interface HistoryControllerDocs {
+
+    @Operation(
+            summary = "이력 생성",
+            description = "현재 저장된 매칭 결과를 기반으로 <b>사용자별로</b> 이력을 생성합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "이력 생성 성공",
+                    content = @Content(schema = @Schema(implementation = HistoryResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "매칭 저장 미실행",
+                    content = @Content(schema = @Schema(implementation = com.likelion.zooting.global.response.ApiResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "저장할 데이터(User)가 없음",
+                    content = @Content(schema = @Schema(implementation = com.likelion.zooting.global.response.ApiResponse.class))
+            )
+    })
+    @PostMapping("/create")
+    ResponseEntity<com.likelion.zooting.global.response.ApiResponse<HistoryResponse>> createHistories();
+}

--- a/src/main/java/com/likelion/zooting/domain/history/dto/HistoryResponse.java
+++ b/src/main/java/com/likelion/zooting/domain/history/dto/HistoryResponse.java
@@ -1,0 +1,24 @@
+package com.likelion.zooting.domain.history.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "이력 저장 결과")
+public record HistoryResponse(
+        @Schema(description = "이력 실행 성공 여부")
+        boolean isComplete,
+        @Schema(description = "전체 참여 사용자 수")
+        Integer totalUserCount,
+        @Schema(description = "매칭된 상태의 사용자 수")
+        Integer matchedUserCount,
+        @Schema(description = "매칭되지 않는 상태의 사용자 수")
+        Integer unmatchedUserCount,
+        @Schema(description = "에러 처리된 사용자 수")
+        Integer erredUserCount,
+        @Schema(description = "이력 저장한 시간")
+        LocalDateTime simulatedAt
+) {
+}

--- a/src/main/java/com/likelion/zooting/domain/history/entity/History.java
+++ b/src/main/java/com/likelion/zooting/domain/history/entity/History.java
@@ -1,6 +1,7 @@
 package com.likelion.zooting.domain.history.entity;
 
 import com.likelion.zooting.domain.match.entity.Matches;
+import com.likelion.zooting.domain.user.entity.Gender;
 import com.likelion.zooting.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -14,26 +15,20 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)  // JPA만 접근 가능
 @Table(name = "HISTORY")
 public class History {
+    // Hostory 설정
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "HISTORY_ID")
     private Long historyId;
 
-    @ManyToOne(fetch = FetchType.LAZY)  // 최적화를 위해 USER를 DB에서 가져오지 않도록 설정
-    @JoinColumn(name = "USER_ID")  // 외래키 설정
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)  // 최적화를 위해 USER를 DB에서 가져오지 않도록 설정
-    @JoinColumn(name = "PARTNER_ID", nullable = true)  // 외래키 설정
-    private User partner;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "STATUS")
-    private HistoryStatus status;   // 이력 상태
+    private HistoryStatus historyStatus;   // 이력 상태
 
     @Column(name = "CREATED_AT", updatable = false)
     private java.time.LocalDateTime createdAt;  // 이력 생성 시점
 
+    // Matches 정보
     @Column(name = "ANIMAL_NUM")
     private Integer animalNum;  // 동물상 일치 개수
 
@@ -46,43 +41,72 @@ public class History {
     @Column(name = "SCORE")
     private Integer score;  // 매칭 점수
 
+    // User 정보
+    @Column(name = "USER_INSTAGRAM_ID")
+    private String userInstagramId;
+
+    @Column(name = "PARTNER_INSTAGRAM_ID")
+    private String partnerInstagramId;
+
+    @Enumerated(EnumType.STRING)    // 데이터 안정성을 위해, DB에 저장할 경우 문자열로 저장할 것을 명시
+    @Column(name = "USER_GENDER", length = 10)
+    private Gender userGender;  // 성별
+
+    @Column(name = "USER_ANIMAL_TYPE")
+    private String userAnimalType;
+
+    @Column(name = "USER_REGISTER_AT", updatable = false) // 수정 못하게 설정
+    private LocalDateTime userRegisterAt;    // 사용자 등록 시간
+
+    @Column(name = "USER_PRIVACY_CONSENT")
+    private boolean userPrivacyConsent;
+
     // 매칭일 경우
-    public static History createMatchedUserHistory(User user, User partner, Matches matches) {
+    public static History createMatchedUserHistory(User user, User partner, Matches matches, String userAnimalType) {
         History history = new History();
-        history.user = user;
-        history.partner = partner;
-        history.status = HistoryStatus.MATCHED;
+        // 이력 정보 삽입
         history.createdAt = LocalDateTime.now();
+        history.historyStatus = HistoryStatus.MATCHED;
+        // 매칭 정보 삽입
         history.animalNum = matches.getAnimalNum();
         history.interestNum = matches.getInterestNum();
         history.movieNum = matches.getMovieNum();
         history.score = matches.getScore();
+        // 사용자 정보 삽입
+        history.userInstagramId = user.getInstagramId();
+        history.partnerInstagramId = partner.getInstagramId();
+        history.userGender = user.getGender();
+        history.userAnimalType = userAnimalType;
+        history.userRegisterAt = user.getCreatedAt();
+        history.userPrivacyConsent = user.isPrivacyConsent();
         return history;
     }
 
-    public static History createUnmatchedUserHistory(User user) {
+    public static History createUnmatchedUserHistory(User user, String userAnimalType) {
         History history = new History();
-        history.user = user;
-        history.partner = null;
-        history.status = HistoryStatus.MATCHED;
+        // 이력 정보 삽입
         history.createdAt = LocalDateTime.now();
-        history.animalNum = null;
-        history.interestNum = null;
-        history.movieNum = null;
-        history.score = null;
+        history.historyStatus = HistoryStatus.FAILED;
+        // 사용자 정보 삽입
+        history.userInstagramId = user.getInstagramId();
+        history.userGender = user.getGender();
+        history.userAnimalType = userAnimalType;
+        history.userRegisterAt = user.getCreatedAt();
+        history.userPrivacyConsent = user.isPrivacyConsent();
         return history;
     }
 
-    public static History createErroredUserHistory(User user) {
+    public static History createErroredUserHistory(User user, String userAnimalType) {
         History history = new History();
-        history.user = user;
-        history.partner = null;
-        history.status = HistoryStatus.ERROR;
+        // 이력 정보 삽입
         history.createdAt = LocalDateTime.now();
-        history.animalNum = null;
-        history.interestNum = null;
-        history.movieNum = null;
-        history.score = null;
+        history.historyStatus = HistoryStatus.ERROR;
+        // 사용자 정보 삽입
+        history.userInstagramId = user.getInstagramId();
+        history.userGender = user.getGender();
+        history.userAnimalType = userAnimalType;
+        history.userRegisterAt = user.getCreatedAt();
+        history.userPrivacyConsent = user.isPrivacyConsent();
         return history;
     }
 }

--- a/src/main/java/com/likelion/zooting/domain/history/entity/History.java
+++ b/src/main/java/com/likelion/zooting/domain/history/entity/History.java
@@ -1,0 +1,88 @@
+package com.likelion.zooting.domain.history.entity;
+
+import com.likelion.zooting.domain.match.entity.Matches;
+import com.likelion.zooting.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // JPA만 접근 가능
+@Table(name = "HISTORY")
+public class History {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "HISTORY_ID")
+    private Long historyId;
+
+    @ManyToOne(fetch = FetchType.LAZY)  // 최적화를 위해 USER를 DB에서 가져오지 않도록 설정
+    @JoinColumn(name = "USER_ID")  // 외래키 설정
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)  // 최적화를 위해 USER를 DB에서 가져오지 않도록 설정
+    @JoinColumn(name = "PARTNER_ID", nullable = true)  // 외래키 설정
+    private User partner;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "STATUS")
+    private HistoryStatus status;   // 이력 상태
+
+    @Column(name = "CREATED_AT", updatable = false)
+    private java.time.LocalDateTime createdAt;  // 이력 생성 시점
+
+    @Column(name = "ANIMAL_NUM")
+    private Integer animalNum;  // 동물상 일치 개수
+
+    @Column(name = "INTEREST_NUM")
+    private Integer interestNum;    // 관심사 일치 개수
+
+    @Column(name = "MOVIE_NUM")
+    private Integer movieNum;   // 영화 장르 일치 개수
+
+    @Column(name = "SCORE")
+    private Integer score;  // 매칭 점수
+
+    // 매칭일 경우
+    public static History createMatchedUserHistory(User user, User partner, Matches matches) {
+        History history = new History();
+        history.user = user;
+        history.partner = partner;
+        history.status = HistoryStatus.MATCHED;
+        history.createdAt = LocalDateTime.now();
+        history.animalNum = matches.getAnimalNum();
+        history.interestNum = matches.getInterestNum();
+        history.movieNum = matches.getMovieNum();
+        history.score = matches.getScore();
+        return history;
+    }
+
+    public static History createUnmatchedUserHistory(User user) {
+        History history = new History();
+        history.user = user;
+        history.partner = null;
+        history.status = HistoryStatus.MATCHED;
+        history.createdAt = LocalDateTime.now();
+        history.animalNum = null;
+        history.interestNum = null;
+        history.movieNum = null;
+        history.score = null;
+        return history;
+    }
+
+    public static History createErroredUserHistory(User user) {
+        History history = new History();
+        history.user = user;
+        history.partner = null;
+        history.status = HistoryStatus.ERROR;
+        history.createdAt = LocalDateTime.now();
+        history.animalNum = null;
+        history.interestNum = null;
+        history.movieNum = null;
+        history.score = null;
+        return history;
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/history/entity/HistoryStatus.java
+++ b/src/main/java/com/likelion/zooting/domain/history/entity/HistoryStatus.java
@@ -1,0 +1,8 @@
+package com.likelion.zooting.domain.history.entity;
+
+public enum HistoryStatus {
+    MATCHED,        // 매칭 성공
+    FAILED,         // 매칭 실패
+    ERROR           // 매칭 에러
+
+}

--- a/src/main/java/com/likelion/zooting/domain/history/exception/HistoryErrorCode.java
+++ b/src/main/java/com/likelion/zooting/domain/history/exception/HistoryErrorCode.java
@@ -1,0 +1,35 @@
+package com.likelion.zooting.domain.history.exception;
+
+import com.likelion.zooting.global.exception.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum HistoryErrorCode implements BaseErrorCode {
+    BEFORE_EXECUTE_MATCH_SAVED("HISTORY_4031", "매칭 저장 미실행",  HttpStatus.FORBIDDEN),
+    NO_USER_FOR_CREATE_HISTORY("HISTORY_4041", "저장할 데이터(User)가 없음",  HttpStatus.NOT_FOUND)
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    HistoryErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/history/repository/HistoryRepository.java
@@ -1,0 +1,9 @@
+package com.likelion.zooting.domain.history.repository;
+
+import com.likelion.zooting.domain.history.entity.History;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HistoryRepository extends JpaRepository<History, Long> {
+}

--- a/src/main/java/com/likelion/zooting/domain/history/sevice/HistoryService.java
+++ b/src/main/java/com/likelion/zooting/domain/history/sevice/HistoryService.java
@@ -1,5 +1,7 @@
 package com.likelion.zooting.domain.history.sevice;
 
+import com.likelion.zooting.domain.animaltype.repository.AnimalTypeRepository;
+import com.likelion.zooting.domain.animaltype.service.converter.AnimalTypeIdToName;
 import com.likelion.zooting.domain.history.dto.HistoryResponse;
 import com.likelion.zooting.domain.history.entity.History;
 import com.likelion.zooting.domain.history.repository.HistoryRepository;
@@ -36,15 +38,20 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 @Transactional
 public class HistoryService {
+    private final AnimalTypeRepository animalTypeRepository;
     private final UserRepository userRepository;
     private final MatchRepository matchRepository;
     private final HistoryRepository historyRepository;
+    private final AnimalTypeIdToName animalTypeIdToName;
     private final HistoryConverter historyConverter;
 
     public HistoryResponse createHistories() {
         // 1. 데이터(사용자, 매칭 결과) 불러오기 및 필요한 변수 설정
         List<User> users = userRepository.findAll();
         List<Matches> matches = matchRepository.findAll();
+
+        // 동물상(ID -> name)처리에 필요한 map
+        Map<Long, String> animalTypeMap = animalTypeIdToName.animalTypesToNames(animalTypeRepository.findAll());
 
         // 방문 여부 체크를 하기 위한 리스트와 그 리스트와 user 리스트(index -> User) 매핑을 위한 인덱스 생성
         boolean[] isVisited = new boolean[users.size()];
@@ -76,25 +83,25 @@ public class HistoryService {
             }
             // ERROR일 경우(1) (이미 이력 생성한 사용자와 매칭)
             else if (male.getStatus() != Status.IN_HISTORY && female.getStatus() == Status.IN_HISTORY) {
-                histories.add(historyConverter.toErrorHistory(male));
+                histories.add(historyConverter.toErrorHistory(male, animalTypeMap));
                 totalUserCount += 1;
                 erredUserCount += 1;
             } else if (male.getStatus() == Status.IN_HISTORY && female.getStatus() != Status.IN_HISTORY) {
-                histories.add(historyConverter.toErrorHistory(female));
+                histories.add(historyConverter.toErrorHistory(female, animalTypeMap));
                 totalUserCount += 1;
                 erredUserCount += 1;
             }
             // ERROR일 경우(2) (user의 상태와 matches의 불일치)
             else if (male.getStatus() != Status.MATCHED || female.getStatus() != Status.MATCHED) {
-                histories.add(historyConverter.toErrorHistory(male));
-                histories.add(historyConverter.toErrorHistory(female));
+                histories.add(historyConverter.toErrorHistory(male, animalTypeMap));
+                histories.add(historyConverter.toErrorHistory(female, animalTypeMap));
                 totalUserCount += 2;
                 erredUserCount += 2;
             }
             // MATCHED일 경우(user의 상태와 matches의 상태 일치)
             else {
-                histories.add(historyConverter.toMaleHistory(m));
-                histories.add(historyConverter.toFemaleHistory(m));
+                histories.add(historyConverter.toMaleHistory(m, animalTypeMap));
+                histories.add(historyConverter.toFemaleHistory(m, animalTypeMap));
                 totalUserCount += 2;
                 matchedUserCount += 2;
             }
@@ -117,11 +124,11 @@ public class HistoryService {
                 }
                 // ERROR일 경우(2) (user의 상태와 matches의 불일치)
                 else if (user.getStatus() == Status.MATCHED) {
-                    histories.add(historyConverter.toErrorHistory(user));
+                    histories.add(historyConverter.toErrorHistory(user, animalTypeMap));
                     totalUserCount++;
                     erredUserCount++;
                 } else {
-                    histories.add(historyConverter.toUnmatchedHistory(user));
+                    histories.add(historyConverter.toUnmatchedHistory(user, animalTypeMap));
                     totalUserCount++;
                     unmatchedUserCount++;
                 }
@@ -129,11 +136,9 @@ public class HistoryService {
             }
         }
 
-        // 4. Batch 처리(모든 생성한 이력 결과들 저장 + match 삭제)
-        // 먼저 DB에 이력 결과 밀어 넣기(혹시 에러 발생 시, matches는 삭제 안됨)
+        // 4. Batch 처리(모든 생성한 이력 결과들 저장)
+        // 먼저 DB에 이력 결과 밀어 넣기(혹시 에러 발생 시 이후의 작업이 멈춤)
         historyRepository.saveAllAndFlush(histories);
-        // matches의 빠른 비우기
-        matchRepository.deleteAllInBatch();
 
         // 5. 결과 반환
         return HistoryResponse.builder()

--- a/src/main/java/com/likelion/zooting/domain/history/sevice/HistoryService.java
+++ b/src/main/java/com/likelion/zooting/domain/history/sevice/HistoryService.java
@@ -1,0 +1,148 @@
+package com.likelion.zooting.domain.history.sevice;
+
+import com.likelion.zooting.domain.history.dto.HistoryResponse;
+import com.likelion.zooting.domain.history.entity.History;
+import com.likelion.zooting.domain.history.repository.HistoryRepository;
+import com.likelion.zooting.domain.history.sevice.converter.HistoryConverter;
+import com.likelion.zooting.domain.match.entity.Matches;
+import com.likelion.zooting.domain.match.repository.MatchRepository;
+import com.likelion.zooting.domain.user.entity.Status;
+import com.likelion.zooting.domain.user.entity.User;
+import com.likelion.zooting.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * <p><b>[이력 상태 처리]</b></p>
+ * <ul>
+ * <li>MATCHED 처리 -> 사용자 상태가 MATCHED이며, 매칭 결과에 사용자가 남아있는 경우</li>
+ * <li>FAILED 처리 -> 사용자 상태가 SUBMITTED로 남아있고, 매칭 결과에 사용자가 등록되어 있지 않는 경우</li>
+ * <li>ERROR 처리 ->
+ *     <ul>
+ *     <li>(1) 이미 이력 관리에 저장된 사용자와 매칭을 이룰 경우</li>
+ *     <li>(2) 상태가 일치하지 않을 경우(SUBMITTED인데 MATCHED일 경우, MATCHED인데 SUBMITTED일 경우)</li></li>
+ *     </ul>
+ * </ul>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HistoryService {
+    private final UserRepository userRepository;
+    private final MatchRepository matchRepository;
+    private final HistoryRepository historyRepository;
+    private final HistoryConverter historyConverter;
+
+    public HistoryResponse createHistories() {
+        // 1. 데이터(사용자, 매칭 결과) 불러오기 및 필요한 변수 설정
+        List<User> users = userRepository.findAll();
+        List<Matches> matches = matchRepository.findAll();
+
+        // 방문 여부 체크를 하기 위한 리스트와 그 리스트와 user 리스트(index -> User) 매핑을 위한 인덱스 생성
+        boolean[] isVisited = new boolean[users.size()];
+        Map<Long, Integer> userIndexMap = IntStream.range(0, users.size())
+                .boxed()
+                .collect(Collectors.toMap(i -> users.get(i).getUserId(), i -> i));
+
+        // Batch 처리할 이력 결과물들
+        List<History> histories = new ArrayList<>();
+
+        // 결과 집계용 변수
+        int totalUserCount = 0;
+        int matchedUserCount = 0;
+        int unmatchedUserCount = 0;
+        int erredUserCount = 0;
+
+        // 2. 매칭 성공 데이터 처리
+        for (Matches m : matches) {
+            User male = m.getMaleUser();
+            User female = m.getFemaleUser();
+
+            int maleIdx = userIndexMap.get(male.getUserId());
+            int femaleIdx = userIndexMap.get(female.getUserId());
+
+            // ERROR 검증(일관된 상태를 유지하는가?)
+            // 이미 이전에 이력처리된 사용자
+            if (male.getStatus() == Status.IN_HISTORY && female.getStatus() == Status.IN_HISTORY) {
+                // 건너뜀
+            }
+            // ERROR일 경우(1) (이미 이력 생성한 사용자와 매칭)
+            else if (male.getStatus() != Status.IN_HISTORY && female.getStatus() == Status.IN_HISTORY) {
+                histories.add(historyConverter.toErrorHistory(male));
+                totalUserCount += 1;
+                erredUserCount += 1;
+            } else if (male.getStatus() == Status.IN_HISTORY && female.getStatus() != Status.IN_HISTORY) {
+                histories.add(historyConverter.toErrorHistory(female));
+                totalUserCount += 1;
+                erredUserCount += 1;
+            }
+            // ERROR일 경우(2) (user의 상태와 matches의 불일치)
+            else if (male.getStatus() != Status.MATCHED || female.getStatus() != Status.MATCHED) {
+                histories.add(historyConverter.toErrorHistory(male));
+                histories.add(historyConverter.toErrorHistory(female));
+                totalUserCount += 2;
+                erredUserCount += 2;
+            }
+            // MATCHED일 경우(user의 상태와 matches의 상태 일치)
+            else {
+                histories.add(historyConverter.toMaleHistory(m));
+                histories.add(historyConverter.toFemaleHistory(m));
+                totalUserCount += 2;
+                matchedUserCount += 2;
+            }
+
+            // 작업 완료 후 상태 업데이트
+            male.updateStatus(Status.IN_HISTORY);
+            female.updateStatus(Status.IN_HISTORY);
+            isVisited[maleIdx] = true;
+            isVisited[femaleIdx] = true;
+        }
+
+        // 3. 매칭 실패(미방문) 유저 처리
+        for (int i = 0; i < users.size(); i++) {
+            // 아직 방문하지 않는 사용자
+            if (!isVisited[i]) {
+                User user = users.get(i);
+                // 이미 IN_HISTORY인 유저는 제외 (혹시라도 이전에 이력 처리 시도했을 경우)
+                if (user.getStatus() == Status.IN_HISTORY) {
+                    // 건너뜀
+                }
+                // ERROR일 경우(2) (user의 상태와 matches의 불일치)
+                else if (user.getStatus() == Status.MATCHED) {
+                    histories.add(historyConverter.toErrorHistory(user));
+                    totalUserCount++;
+                    erredUserCount++;
+                } else {
+                    histories.add(historyConverter.toUnmatchedHistory(user));
+                    totalUserCount++;
+                    unmatchedUserCount++;
+                }
+                user.updateStatus(Status.IN_HISTORY);
+            }
+        }
+
+        // 4. Batch 처리(모든 생성한 이력 결과들 저장 + match 삭제)
+        // 먼저 DB에 이력 결과 밀어 넣기(혹시 에러 발생 시, matches는 삭제 안됨)
+        historyRepository.saveAllAndFlush(histories);
+        // matches의 빠른 비우기
+        matchRepository.deleteAllInBatch();
+
+        // 5. 결과 반환
+        return HistoryResponse.builder()
+                .isComplete(true)
+                .totalUserCount(totalUserCount)
+                .matchedUserCount(matchedUserCount)
+                .unmatchedUserCount(unmatchedUserCount)
+                .erredUserCount(erredUserCount)
+                .simulatedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/history/sevice/converter/HistoryConverter.java
+++ b/src/main/java/com/likelion/zooting/domain/history/sevice/converter/HistoryConverter.java
@@ -5,6 +5,8 @@ import com.likelion.zooting.domain.match.entity.Matches;
 import com.likelion.zooting.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 public class HistoryConverter {
     /**
@@ -12,16 +14,24 @@ public class HistoryConverter {
      * @param matches 매칭 정보
      * @return 남성 기준으로 생성된 이력 결과
      */
-    public History toMaleHistory(Matches matches){
-        return History.createMatchedUserHistory(matches.getMaleUser(), matches.getFemaleUser(), matches);
+    public History toMaleHistory(Matches matches, Map<Long, String> animalTypeMap){
+        String userAnimalType = animalTypeMap.get(matches
+                .getMaleUser()
+                .getAnimalType()
+                .getAnimalTypeId());
+        return History.createMatchedUserHistory(matches.getMaleUser(), matches.getFemaleUser(), matches, userAnimalType);
     }
     /**
      * 여성 사용자에 대한 매칭 상태 history 변환(여성 -> user, 남성 -> partner)
      * @param matches 매칭 정보
      * @return 여성 기준으로 생성된 이력 결과
      */
-    public History toFemaleHistory(Matches matches){
-        return History.createMatchedUserHistory(matches.getFemaleUser(), matches.getFemaleUser(), matches);
+    public History toFemaleHistory(Matches matches, Map<Long, String> animalTypeMap){
+        String userAnimalType = animalTypeMap.get(matches
+                .getFemaleUser()
+                .getAnimalType()
+                .getAnimalTypeId());
+        return History.createMatchedUserHistory(matches.getFemaleUser(), matches.getMaleUser(), matches,  userAnimalType);
     }
 
     /**
@@ -29,8 +39,11 @@ public class HistoryConverter {
      * @param user 매칭되지 않는 사용자
      * @return 매칭 안됨 상태의 이력 결과
      */
-    public History toUnmatchedHistory(User user){
-        return History.createUnmatchedUserHistory(user);
+    public History toUnmatchedHistory(User user, Map<Long, String> animalTypeMap){
+        String userAnimalType = animalTypeMap.get(user
+                .getAnimalType()
+                .getAnimalTypeId());
+        return History.createUnmatchedUserHistory(user, userAnimalType);
     }
 
     /**
@@ -38,7 +51,10 @@ public class HistoryConverter {
      * @param user 오류가 발생한 사용자
      * @return 오류 상태의 이력 결과
      */
-    public History toErrorHistory(User user){
-        return History.createErroredUserHistory(user);
+    public History toErrorHistory(User user, Map<Long, String> animalTypeMap){
+        String userAnimalType = animalTypeMap.get(user
+                .getAnimalType()
+                .getAnimalTypeId());
+        return History.createErroredUserHistory(user, userAnimalType);
     }
 }

--- a/src/main/java/com/likelion/zooting/domain/history/sevice/converter/HistoryConverter.java
+++ b/src/main/java/com/likelion/zooting/domain/history/sevice/converter/HistoryConverter.java
@@ -1,0 +1,44 @@
+package com.likelion.zooting.domain.history.sevice.converter;
+
+import com.likelion.zooting.domain.history.entity.History;
+import com.likelion.zooting.domain.match.entity.Matches;
+import com.likelion.zooting.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HistoryConverter {
+    /**
+     * 남성 사용자에 대한 매칭 상태 history 변환(남성 -> user, 여성 -> partner)
+     * @param matches 매칭 정보
+     * @return 남성 기준으로 생성된 이력 결과
+     */
+    public History toMaleHistory(Matches matches){
+        return History.createMatchedUserHistory(matches.getMaleUser(), matches.getFemaleUser(), matches);
+    }
+    /**
+     * 여성 사용자에 대한 매칭 상태 history 변환(여성 -> user, 남성 -> partner)
+     * @param matches 매칭 정보
+     * @return 여성 기준으로 생성된 이력 결과
+     */
+    public History toFemaleHistory(Matches matches){
+        return History.createMatchedUserHistory(matches.getFemaleUser(), matches.getFemaleUser(), matches);
+    }
+
+    /**
+     * 사용자에 대한 매칭되지 않는 상태의 history 변환
+     * @param user 매칭되지 않는 사용자
+     * @return 매칭 안됨 상태의 이력 결과
+     */
+    public History toUnmatchedHistory(User user){
+        return History.createUnmatchedUserHistory(user);
+    }
+
+    /**
+     * 사용자에 대한 오류 상태의 history 변환
+     * @param user 오류가 발생한 사용자
+     * @return 오류 상태의 이력 결과
+     */
+    public History toErrorHistory(User user){
+        return History.createErroredUserHistory(user);
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/match/controller/MatchController.java
+++ b/src/main/java/com/likelion/zooting/domain/match/controller/MatchController.java
@@ -7,6 +7,7 @@ import com.likelion.zooting.global.exception.GeneralException;
 import com.likelion.zooting.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +20,7 @@ public class MatchController implements MatchControllerDocs {
     private final MatchService matchService;
 
     @Override
+    @PostMapping("/simulate")
     public ResponseEntity<ApiResponse<MatchResponse>> simulateMatch() {
         // 시간 검증 로직 분리
         validateMatchTime();
@@ -29,6 +31,7 @@ public class MatchController implements MatchControllerDocs {
     }
 
     @Override
+    @PostMapping("/run")
     public ResponseEntity<ApiResponse<MatchResponse>> runMatch() {
         // 시간 검증 로직 분리
         validateMatchTime();

--- a/src/main/java/com/likelion/zooting/domain/match/controller/MatchControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/match/controller/MatchControllerDocs.java
@@ -8,11 +8,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "Match", description = "매칭 관련 API")
-@RequestMapping("/api/internal/match")
 public interface MatchControllerDocs {
 
     @Operation(
@@ -36,7 +33,6 @@ public interface MatchControllerDocs {
                     content = @Content(schema = @Schema(implementation = com.likelion.zooting.global.response.ApiResponse.class))
             )
     })
-    @PostMapping("/simulate")
     ResponseEntity<com.likelion.zooting.global.response.ApiResponse<MatchResponse>> simulateMatch();
 
     @Operation(
@@ -65,6 +61,5 @@ public interface MatchControllerDocs {
                     content = @Content(schema = @Schema(implementation = com.likelion.zooting.global.response.ApiResponse.class))
             )
     })
-    @PostMapping("/run")
     ResponseEntity<com.likelion.zooting.global.response.ApiResponse<MatchResponse>> runMatch();
 }

--- a/src/main/java/com/likelion/zooting/domain/user/entity/Status.java
+++ b/src/main/java/com/likelion/zooting/domain/user/entity/Status.java
@@ -4,5 +4,6 @@ public enum Status {
     IN_PROGRESS,    // 설문 작성 중
     SUBMITTED,      // 설문 제출 완료
     MATCHED,        // 매칭 성공
-    FAILED          // 매칭 실패
+    FAILED,         // 매칭 실패
+    IN_HISTORY      // 이력 저장 완료
 }


### PR DESCRIPTION
## 연관된 이슈
- #42 

---

## 작업 내용
- API 엔드포인트(@RequestMapping, @PostMapping 등) 설정을 인터페이스(Docs)에서 실제 구현체(Controller)로 이전했습니다.

### 작업 내용
- MatchControllerDocs의 엔드포인트 설정을 MatchController로 이동
- HistoryControllerDocs의 엔드포인트 설정을 HistoryController로 이동

---

## 기대 효과
- 인터페이스는 오직 Swagger 문서화 역할만 수행하도록 책임을 분리한다.
- 엔드포인트 설정의 가독성을 높이고 관리 주체를 일관화 한다.

---