### PR TITLE
[Feat] 매칭 결과 확인 API

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultController.java
+++ b/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultController.java
@@ -1,0 +1,27 @@
+package com.likelion.zooting.domain.match.controller;
+
+import com.likelion.zooting.domain.match.dto.MatchResultRequest;
+import com.likelion.zooting.domain.match.dto.MatchResultResponse;
+import com.likelion.zooting.domain.match.service.MatchResultService;
+import com.likelion.zooting.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/match")
+@RequiredArgsConstructor
+public class MatchResultController {
+
+  private final MatchResultService matchResultService;
+
+  @PostMapping("/result")
+  public ResponseEntity<ApiResponse<MatchResultResponse>> getMatchResult(
+      @Valid @RequestBody MatchResultRequest request
+  ) {
+    MatchResultResponse response = matchResultService.getMatchResult(request);
+
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+}

--- a/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultControllerDocs.java
@@ -1,0 +1,31 @@
+package com.likelion.zooting.domain.match.controller;
+
+import com.likelion.zooting.domain.match.dto.MatchResultRequest;
+import com.likelion.zooting.domain.match.dto.MatchResultResponse;
+import com.likelion.zooting.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Match", description = "매칭 관련 API")
+public interface MatchResultControllerDocs {
+
+  @Operation(
+      summary = "매칭 결과 확인 API",
+      description = """
+                    사용자가 입력한 인스타 ID와 본인확인용 4자리 숫자를 검증한 후,
+                    18시 이후 매칭 결과를 조회합니다.
+                    
+                    - Request Body로 instagramId, verificationPin을 전달합니다.
+                    - 18시 이전에는 매칭 결과를 조회할 수 없습니다.
+                    - 매칭 성공 시 상대방 인스타 ID를 반환합니다.
+                    - 매칭된 사용자가 없을 경우 isMatched=false를 반환합니다.
+                    """
+  )
+  ResponseEntity<ApiResponse<MatchResultResponse>> getMatchResult(
+      @Valid @RequestBody MatchResultRequest request
+  );
+}

--- a/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultRequest.java
+++ b/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultRequest.java
@@ -1,0 +1,15 @@
+package com.likelion.zooting.domain.match.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record MatchResultRequest(
+
+    @NotBlank(message = "인스타 ID는 필수입니다.")
+    String instagramId,
+
+    @NotBlank(message = "본인확인용 숫자는 필수입니다.")
+    @Pattern(regexp = "\\d{4}", message = "본인확인용 숫자는 숫자 4자리여야 합니다.")
+    String verificationPin
+) {
+}

--- a/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultResponse.java
+++ b/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultResponse.java
@@ -1,0 +1,18 @@
+package com.likelion.zooting.domain.match.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MatchResultResponse(
+    boolean isMatched,
+    String partnerInstagramId
+) {
+
+  public static MatchResultResponse matched(String partnerInstagramId) {
+    return new MatchResultResponse(true, partnerInstagramId);
+  }
+
+  public static MatchResultResponse notMatched() {
+    return new MatchResultResponse(false, null);
+  }
+}

--- a/src/main/java/com/likelion/zooting/domain/match/exception/MatchErrorCode.java
+++ b/src/main/java/com/likelion/zooting/domain/match/exception/MatchErrorCode.java
@@ -5,19 +5,20 @@ import org.springframework.http.HttpStatus;
 
 /**
  * matching 도메인에서 발생할 수 있는 에러를 반환하기 위해 사용되는 Enum
- * <p>
- * 에러 코드 : [에러가 발생한 도메인] + "_" + [에러코드] + [고유 식별자]
- * 메시지 : 에러가 발생한 상황에 대한 상세 설명
- * HttpStatus : 반환할 HTTP 상태 코드
  */
 public enum MatchErrorCode implements BaseErrorCode {
     MATCH_TIME_FORBIDDEN("MATCH_4032", "실제 매칭은 17시 이후에만 실행할 수 있습니다.", HttpStatus.FORBIDDEN),
 
     NO_MATCHED_USER_CANDIDATES("MATCH_4041", "매칭 대상 사용자가 없습니다.", HttpStatus.NOT_FOUND),
-
+    MATCH_RESULT_NOT_FOUND("MATCH_4041", "매칭 결과를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DUPLICATE_EXECUTION_OF_MATCH_SAVE("MATCH_4091", "이미 매칭 결과가 저장되어 있습니다.", HttpStatus.CONFLICT),
-    ;
 
+    // [추가] 신규 에러 코드 (생성자 순서: code, message, status)
+    USER_4001("USER_4001", "인스타 ID는 필수입니다.", HttpStatus.BAD_REQUEST),
+    USER_4002("USER_4002", "본인확인용 숫자는 숫자 4자리여야 합니다.", HttpStatus.BAD_REQUEST),
+    AUTH_4011("AUTH_4011", "본인확인 정보가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    MATCH_4031("MATCH_4031", "매칭 결과는 18시 이후에 확인할 수 있습니다.", HttpStatus.FORBIDDEN),
+    MATCH_4041("MATCH_4041", "매칭 결과를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
     private final String code;
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/likelion/zooting/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/match/repository/MatchRepository.java
@@ -4,9 +4,24 @@ import com.likelion.zooting.domain.match.entity.Matches;
 import com.likelion.zooting.domain.user.entity.Gender;
 import com.likelion.zooting.domain.user.entity.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-@Repository
+import java.util.Optional;
+
 public interface MatchRepository extends JpaRepository<Matches, Long> {
+
     boolean existsByMaleUser_GenderAndMaleUser_Status(Gender gender, Status status);
+
+    // 사용자 ID가 남성/여성 사용자 중 하나로 포함된 매칭 결과를 조회한다.
+    // 상대방 User까지 함께 로딩하여 partnerInstagramId 조회 시 추가 쿼리를 줄인다.
+    @Query("""
+        select m
+        from Matches m
+        join fetch m.maleUser
+        join fetch m.femaleUser
+        where m.maleUser.userId = :userId
+           or m.femaleUser.userId = :userId
+    """)
+    Optional<Matches> findByUserIdWithUsers(@Param("userId") Long userId);
 }

--- a/src/main/java/com/likelion/zooting/domain/match/service/MatchResultService.java
+++ b/src/main/java/com/likelion/zooting/domain/match/service/MatchResultService.java
@@ -1,0 +1,74 @@
+package com.likelion.zooting.domain.match.service;
+
+import com.likelion.zooting.domain.match.dto.MatchResultRequest;
+import com.likelion.zooting.domain.match.dto.MatchResultResponse;
+import com.likelion.zooting.domain.match.entity.Matches;
+import com.likelion.zooting.domain.match.exception.MatchErrorCode;
+import com.likelion.zooting.domain.match.repository.MatchRepository;
+import com.likelion.zooting.domain.user.entity.User;
+import com.likelion.zooting.domain.user.exception.UserErrorCode;
+import com.likelion.zooting.domain.user.repository.UserRepository;
+import com.likelion.zooting.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchResultService {
+
+  private static final LocalTime MATCH_RESULT_OPEN_TIME = LocalTime.of(18, 0);
+  private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+  private final UserRepository userRepository;
+  private final MatchRepository matchRepository;
+
+  public MatchResultResponse getMatchResult(MatchResultRequest request) {
+    validateAfterOpenTime();
+
+    User user = userRepository.findByInstagramId(request.instagramId())
+        .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+    validateVerificationPin(user, request.verificationPin());
+
+    return matchRepository.findByUserIdWithUsers(user.getUserId())
+        .map(matches -> {
+          User partner = findPartnerUser(matches, user.getUserId());
+          return MatchResultResponse.matched(partner.getInstagramId());
+        })
+        .orElseGet(MatchResultResponse::notMatched);
+  }
+
+  // 현재 사용자가 포함된 매칭 결과에서 상대방 사용자를 찾는다.
+  private User findPartnerUser(Matches matches, Long userId) {
+    if (matches.getMaleUser().getUserId().equals(userId)) {
+      return matches.getFemaleUser();
+    }
+
+    if (matches.getFemaleUser().getUserId().equals(userId)) {
+      return matches.getMaleUser();
+    }
+
+    throw new GeneralException(MatchErrorCode.MATCH_RESULT_NOT_FOUND);
+  }
+
+  // 매칭 결과는 18시 이후에만 조회할 수 있다.
+  private void validateAfterOpenTime() {
+    LocalTime now = LocalTime.now(KOREA_ZONE_ID);
+
+    if (now.isBefore(MATCH_RESULT_OPEN_TIME)) {
+      throw new GeneralException(MatchErrorCode.MATCH_TIME_FORBIDDEN);
+    }
+  }
+
+  // 사용자가 입력한 본인확인용 숫자가 DB에 저장된 값과 일치하는지 검증한다.
+  private void validateVerificationPin(User user, String verificationPin) {
+    if (!user.getUserPw().equals(verificationPin)) {
+      throw new GeneralException(UserErrorCode.PIN_MISMATCH);
+    }
+  }
+}

--- a/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
@@ -35,7 +35,9 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/actuator/health",
                                 "/actuator/prometheus",
-                                "/api/onboarding/instagram"
+                                "/api/onboarding/instagram",
+                                "/api/match/result",
+                                "/api/internal/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 연관된 이슈
- #38

---

## 작업 내용
사용자가 자신의 인스타그램 ID와 PIN 번호를 입력하여 매칭 결과를 확인할 수 있는 API를 구현했습니다.

### 1. 매칭 결과 조회 컨트롤러 구현 (`MatchResultController`)
- `POST /api/match/result` 엔드포인트를 통해 매칭 결과 조회 기능을 구현했습니다.
- `@Valid`를 사용하여 요청 데이터(`MatchResultRequest`)의 유효성을 검증합니다.

### 2. 비즈니스 로직 및 제약 사항 구현 (`MatchResultService`)
- **조회 시간 제한**: 한국 시간 기준 **18시 이후**에만 매칭 결과를 조회할 수 있도록 제한 로직을 추가했습니다.
- **PIN 번호 검증**: 사용자가 입력한 PIN 번호(`verificationPin`)와 DB에 저장된 값(`userPw`)이 일치하는지 확인하여 본인 인증을 수행합니다.
- **상대방 정보 추출**: 매칭 정보(`Matches`)에서 현재 사용자의 ID를 제외한 상대방의 인스타그램 ID를 찾아 반환합니다.
- **예외 처리**: 사용자 미존재(`USER_NOT_FOUND`), PIN 불일치(`PIN_MISMATCH`), 시간 외 접근(`MATCH_TIME_FORBIDDEN`) 등 상황별 예외 처리를 적용했습니다.

---

## 기대 효과
- 정해진 시간(18시) 이후에만 결과를 공개하여 서비스 운영 의도에 맞는 긴장감을 제공합니다.
- PIN 번호를 통한 검증으로 매칭 결과 노출에 대한 보안성을 높였습니다.
- 명확한 예외 메시지를 통해 사용자의 오입력이나 접근 제한 상황을 안내합니다.