### PR TITLE
[FIX] SecurityConfig에 매칭 및 내부 API 경로 허용 추가

### DIFF
--- a/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
                                 "/actuator/health",
                                 "/actuator/prometheus",
                                 "/api/onboarding/instagram",
+                                "/api/internal/**",
+                                "/api/match/result"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 연관된 이슈
- #38 (이전 PR관련 누락분 수정)

---

## 작업 내용
이전 매칭 결과 확인 API 구현 PR(#44)에서 누락되었던 시큐리티 설정 및 추가 경로 허용 작업을 수행했습니다.

### 1. 시큐리티 필터 체인 설정 보완 (`SecurityConfig`)
- 매칭 결과 조회를 위한 엔드포인트(`/api/match/result`)를 `permitAll()` 대상에 추가하여 인증 없이 접근 가능하도록 수정했습니다.
- 내부 API 통신을 위한 경로(`/api/internal/**`)에 대한 접근 허용 설정을 추가했습니다.

### 2. 기타 도메인 로직 보완
- `MatchService`, `OnboardingController`, `MockController` 등에서 발생한 마이너 수정사항 및 충돌 해결 과정에서 누락된 코드를 반영했습니다.

---

## 기대 효과
- 시큐리티 설정 오류로 인해 매칭 결과 API 호출 시 401/403 에러가 발생하는 현상을 방지합니다.
- 내부 시스템 간의 원활한 통신을 보장합니다.
- `dev` 브랜치의 최신 상태와 로컬 작업 내역의 동기화를 완료합니다.