### PR TITLE
[FIX] MockController 중복 엔드포인트 비활성화

### DIFF
--- a/src/main/java/com/likelion/zooting/global/mock/MockController.java
+++ b/src/main/java/com/likelion/zooting/global/mock/MockController.java
@@ -40,11 +40,11 @@ public class MockController {
 //        ));
 //    }
 
-    @PostMapping("/match/result")
-    public ApiResponse<Map<String, Object>> getMatchResult() {
-        return ApiResponse.success(Map.of(
-                "partnerName", "홍길동",
-                "score", 95
-        ));
-    }
+//    @PostMapping("/match/result")
+//    public ApiResponse<Map<String, Object>> getMatchResult() {
+//        return ApiResponse.success(Map.of(
+//                "partnerName", "홍길동",
+//                "score", 95
+//        ));
+//    }
 }


### PR DESCRIPTION
## 연관된 이슈
- #46

---

## 작업 내용
MockController에 남아있던 Mock API 엔드포인트가 실제 운영 API와 중복되어, Spring Boot 애플리케이션 기동 시 매핑 충돌이 발생할 가능성이 있어 이를 비활성화했습니다.

특히 `/match/result` Mock API가 실제 매칭 결과 조회 API와 동일한 경로로 등록될 경우, Spring에서 요청을 처리할 컨트롤러를 명확히 판단하지 못해 애플리케이션 기동 실패로 이어질 수 있습니다.

이번 수정에서는 운영 환경에서 사용하지 않는 MockController의 잔여 엔드포인트를 주석 처리하여 실제 API와의 충돌을 방지했습니다.

### 1. MockController 잔여 엔드포인트 비활성화
- MockController에 남아있던 `/match/result` Mock API를 주석 처리했습니다.
- 실제 매칭 결과 조회 API와의 엔드포인트 중복 가능성을 제거했습니다.

### 2. 배포 장애 원인 제거
- 중복 매핑으로 인한 Spring Boot 기동 실패 가능성을 제거했습니다.
- EC2 배포 후 Nginx에서 Spring Boot 서버로 정상 연결하지 못해 502 Bad Gateway가 발생할 수 있는 문제를 방지했습니다.

---

## 기대 효과
- Spring Boot 애플리케이션 기동 안정성 향상
- 실제 운영 API와 Mock API 간 매핑 충돌 방지
- EC2 자동 배포 후 health check 실패 가능성 감소
- 502 Bad Gateway 발생 원인 제거