### PR TITLE
[FIX] 온보딩 입력값 검증 및 에러 코드 정리

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/onboarding/exception/OnboardingErrorCode.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/exception/OnboardingErrorCode.java
@@ -5,13 +5,18 @@ import org.springframework.http.HttpStatus;
 
 public enum OnboardingErrorCode implements BaseErrorCode {
 
-  GENDER_REQUIRED("USER_4003", "성별은 필수입니다.", HttpStatus.BAD_REQUEST),
-  INTEREST_COUNT_INVALID("USER_4004", "관심사는 정확히 3개 선택해야 합니다.", HttpStatus.BAD_REQUEST),
-  MOVIE_GENRE_COUNT_INVALID("USER_4005", "영화 장르는 정확히 2개 선택해야 합니다.", HttpStatus.BAD_REQUEST),
-  ANIMAL_TYPE_COUNT_INVALID("USER_4006", "선호 동물상은 정확히 3개 선택해야 합니다.", HttpStatus.BAD_REQUEST),
+  GENDER_REQUIRED("ONBOARDING_4001", "성별은 필수입니다.", HttpStatus.BAD_REQUEST),
+
+  INTEREST_COUNT_INVALID("ONBOARDING_4002", "관심사는 정확히 3개 선택해야 합니다.", HttpStatus.BAD_REQUEST),
+  MOVIE_GENRE_COUNT_INVALID("ONBOARDING_4003", "영화 장르는 정확히 2개 선택해야 합니다.", HttpStatus.BAD_REQUEST),
+  ANIMAL_TYPE_COUNT_INVALID("ONBOARDING_4004", "선호 동물상은 정확히 3개 선택하거나 상관없음을 선택해야 합니다.", HttpStatus.BAD_REQUEST),
+
+  ANIMAL_TYPE_NOT_FOUND("ONBOARDING_4005", "존재하지 않는 동물상입니다.", HttpStatus.BAD_REQUEST),
+  INTEREST_NOT_FOUND("ONBOARDING_4006", "존재하지 않는 관심사입니다.", HttpStatus.BAD_REQUEST),
+  MOVIE_GENRE_NOT_FOUND("ONBOARDING_4007", "존재하지 않는 영화 장르입니다.", HttpStatus.BAD_REQUEST),
 
   // 프로필 조회 시 온보딩 미완료 상태 대응
-  ONBOARDING_NOT_FOUND("USER_4042", "온보딩 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+  ONBOARDING_NOT_FOUND("ONBOARDING_4041", "온보딩 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/likelion/zooting/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/service/OnboardingService.java
@@ -51,75 +51,95 @@ public class OnboardingService {
       throw new GeneralException(UserErrorCode.ALREADY_COMPLETED);
     }
 
-    // 3. 본인 동물상 조회
+    // 3. 성별 검증
+    if (request.gender() == null || request.gender().isBlank()) {
+      throw new GeneralException(OnboardingErrorCode.GENDER_REQUIRED);
+    }
+
+    Gender gender = Gender.valueOf(request.gender().toUpperCase());
+
+    // 4. 본인 동물상 조회
     String myAnimalName = request.animalType();
 
     AnimalType myAnimal = animalTypeRepository.findByAnimalName(myAnimalName)
-        .orElseThrow(() -> new GeneralException(OnboardingErrorCode.ANIMAL_TYPE_COUNT_INVALID));
+            .orElseThrow(() -> new GeneralException(OnboardingErrorCode.ANIMAL_TYPE_NOT_FOUND));
 
-    // 4. User 정보 업데이트 (성별 + 본인 동물상)
-    user.updateOnboarding(Gender.valueOf(request.gender().toUpperCase()), myAnimal);
+    // 5. User 정보 업데이트 (성별 + 본인 동물상)
+    user.updateOnboarding(gender, myAnimal);
 
-    // 5. 선호 동물상 저장 로직
+    // 6. 선호 동물상 저장 로직
     List<String> preferredList = request.preferredAnimals();
 
     if (preferredList == null || preferredList.isEmpty()) {
       throw new GeneralException(OnboardingErrorCode.ANIMAL_TYPE_COUNT_INVALID);
     }
 
-// "상관없음" 선택 여부 확인
+    // "상관없음" 선택 여부 확인
     boolean isIndifferent = preferredList.size() == 1 && "상관없음".equals(preferredList.get(0));
 
     if (isIndifferent) {
       // 성별에 따른 모든 가능한 동물상 조회 (COMMON + 사용자 성별 전용)
       // 예: MALE일 경우 COMMON(강아지, 고양이, 햄스터) + MALE(곰, 원숭이, 공룡)
       List<AnimalType> allPossibleAnimals = animalTypeRepository.findByScopeIn(
-          List.of(Scope.COMMON, Scope.valueOf(user.getGender().name().toUpperCase()))
+              List.of(Scope.COMMON, Scope.valueOf(user.getGender().name()))
       );
 
       for (AnimalType animalType : allPossibleAnimals) {
         preferredAnimalRepository.save(new UserPreferredAnimalType(user, animalType));
       }
+
     } else if (preferredList.size() == 3) {
       // 일반적인 3개 선택 로직
       for (String animalName : preferredList) {
         AnimalType animalType = animalTypeRepository.findByAnimalName(animalName)
             .orElseThrow(() -> new GeneralException(OnboardingErrorCode.ANIMAL_TYPE_NOT_FOUND));
+
         preferredAnimalRepository.save(new UserPreferredAnimalType(user, animalType));
       }
+
     } else {
       // 1개(상관없음 아님)나 2개 등을 선택한 경우 에러 처리
       throw new GeneralException(OnboardingErrorCode.ANIMAL_TYPE_COUNT_INVALID);
     }
 
-    // 6. 관심사 저장
+    // 7. 관심사 검증 및 저장
     List<String> interestList = request.interests();
+
+    if (interestList == null || interestList.size() != 3) {
+      throw new GeneralException(OnboardingErrorCode.INTEREST_COUNT_INVALID);
+    }
 
     for (String interestName : interestList) {
       String cleanedInterest = interestName.replace("#", "").trim();
+
       Interest interest = interestRepository.findByInterestName(cleanedInterest)
-          .orElseThrow(() -> new GeneralException(OnboardingErrorCode.INTEREST_COUNT_INVALID));
+              .orElseThrow(() -> new GeneralException(OnboardingErrorCode.INTEREST_NOT_FOUND));
 
       UserInterest userInterest = new UserInterest(user, interest);
       userInterestRepository.save(userInterest);
     }
 
-    // 7. 영화 장르 저장
+    // 8. 영화 장르 검증 및 저장
     List<String> movieGenreList = request.movieGenres();
+
+    if (movieGenreList == null || movieGenreList.size() != 2) {
+      throw new GeneralException(OnboardingErrorCode.MOVIE_GENRE_COUNT_INVALID);
+    }
 
     for (String genreName : movieGenreList) {
       String cleanedGenre = genreName.replace("#", "").trim();
+
       MovieGenre movieGenre = movieGenreRepository.findByMovieGenreName(cleanedGenre)
-          .orElseThrow(() -> new GeneralException(OnboardingErrorCode.MOVIE_GENRE_COUNT_INVALID));
+              .orElseThrow(() -> new GeneralException(OnboardingErrorCode.MOVIE_GENRE_NOT_FOUND));
 
       UserMovieGenre userMovieGenre = new UserMovieGenre(user, movieGenre);
       userMovieGenreRepository.save(userMovieGenre);
     }
 
-    // 8. 상태 전이 - IN_PROGRESS → SUBMITTED
+    // 9. 상태 전이 - IN_PROGRESS → SUBMITTED
     user.markSubmitted();
 
-    // 9. 결과 반환
+    // 10. 결과 반환
     return true;
   }
 }


### PR DESCRIPTION
## 연관된 이슈
- #50

---

## 작업 내용
온보딩 최종 제출 API의 입력값 검증 로직과 에러 코드를 정리하였습니다.

기존에는 동물상 관련 검증은 일부 분리되어 있었지만, 관심사와 영화 장르는 존재하지 않는 값이 들어와도 개수 오류로 처리되고 있었습니다.  
이번 PR에서는 개수 오류와 존재하지 않는 값에 대한 오류를 분리하여, 클라이언트가 실패 원인을 더 명확하게 파악할 수 있도록 수정하였습니다.

### 1. 온보딩 에러 코드 정리

- 온보딩 도메인에서 사용하던 에러 코드 prefix를 `USER_`에서 `ONBOARDING_`으로 변경하였습니다.
- 존재하지 않는 입력값에 대응하기 위한 에러 코드를 추가하였습니다.
  - `ANIMAL_TYPE_NOT_FOUND`
  - `INTEREST_NOT_FOUND`
  - `MOVIE_GENRE_NOT_FOUND`

### 2. 입력값 개수 검증 추가

- 관심사는 정확히 3개 선택해야 하도록 검증을 추가하였습니다.
- 영화 장르는 정확히 2개 선택해야 하도록 검증을 추가하였습니다.
- 선호 동물상은 기존 정책에 맞게 3개 선택 또는 `상관없음` 선택만 허용하도록 유지하였습니다.

### 3. 조회 실패 에러 분리

- 본인 동물상 조회 실패 시 `ANIMAL_TYPE_NOT_FOUND`를 반환하도록 수정하였습니다.
- 관심사 조회 실패 시 `INTEREST_NOT_FOUND`를 반환하도록 수정하였습니다.
- 영화 장르 조회 실패 시 `MOVIE_GENRE_NOT_FOUND`를 반환하도록 수정하였습니다.
- 기존처럼 존재하지 않는 값에 대해 `COUNT_INVALID`가 반환되지 않도록 개선하였습니다.

---

## 기대 효과

- 온보딩 API의 예외 응답이 더 명확해집니다.
- 프론트엔드에서 개수 오류와 존재하지 않는 값 오류를 구분하여 처리할 수 있습니다.
- 온보딩 도메인의 에러 코드 네이밍 일관성이 개선됩니다.
- 잘못된 요청값에 대한 디버깅이 쉬워집니다.