### PR TITLE
[FIX] 매칭 결과 Mock API 비활성화

### DIFF
--- a/src/main/java/com/likelion/zooting/global/mock/MockController.java
+++ b/src/main/java/com/likelion/zooting/global/mock/MockController.java
@@ -40,11 +40,11 @@ public class MockController {
 //        ));
 //    }
 
-    @PostMapping("/match/result")
-    public ApiResponse<Map<String, Object>> getMatchResult() {
-        return ApiResponse.success(Map.of(
-                "partnerName", "홍길동",
-                "score", 95
-        ));
-    }
+//    @PostMapping("/match/result")
+//    public ApiResponse<Map<String, Object>> getMatchResult() {
+//        return ApiResponse.success(Map.of(
+//                "partnerName", "홍길동",
+//                "score", 95
+//        ));
+//    }
 }


### PR DESCRIPTION
## 연관된 이슈
- #52

---

## 작업 내용
`MockController`에 남아 있던 매칭 결과 Mock API를 비활성화하였습니다.

이전에 해당 코드를 주석 처리하여 PR 및 Merge까지 진행했으나, GitHub에 수정 사항이 정상적으로 반영되지 않아 다시 변경 사항을 반영합니다.

### 1. 매칭 결과 Mock API 비활성화

- `/match/result` Mock API를 주석 처리하였습니다.
- `partnerName`, `score`를 반환하던 더미 응답 코드를 비활성화하였습니다.
- 실제 매칭 결과 API와 혼동될 수 있는 Mock 엔드포인트를 제거하였습니다.

---

## 기대 효과

- 불필요한 Mock API 노출을 방지할 수 있습니다.
- 실제 매칭 결과 API와 Mock API 간 혼동을 줄일 수 있습니다.
- GitHub에 누락된 변경 사항을 다시 반영할 수 있습니다.