### PR TITLE
[FIX] 선호 동물상 상관없음 선택 검증 오류 수정

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/onboarding/dto/OnboardingRequest.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/dto/OnboardingRequest.java
@@ -12,7 +12,7 @@ public record OnboardingRequest(
     String animalType,
 
     @NotNull
-    @Size(min = 3, max = 3, message = "원하는 상대 동물상은 정확히 3개를 선택해야 합니다")
+    @NotEmpty(message = "원하는 상대 동물상은 필수입니다.")
     List<String> preferredAnimals,
 
     @NotNull


### PR DESCRIPTION
## 연관된 이슈
- #54

---

## 작업 내용
선호 동물상에서 `상관없음`을 선택할 때 발생하던 온보딩 검증 오류를 수정하였습니다.

기존에는 `preferredAnimals` 필드에 `@Size(min = 3, max = 3)` 검증이 적용되어 있어, `"상관없음"` 1개만 전달되는 경우 컨트롤러 진입 전에 유효성 검증에서 실패하였습니다.

이번 PR에서는 DTO의 고정 개수 검증을 제거하고, 선호 동물상 선택 정책을 서비스 계층에서 처리하도록 수정하였습니다.

### 1. DTO 검증 조건 수정

- `preferredAnimals` 필드에서 `@Size(min = 3, max = 3)` 검증을 제거하였습니다.
- 필수 입력 여부만 검증하도록 `@NotNull` 또는 `@NotEmpty` 검증을 유지하였습니다.
- `상관없음` 선택 시 `"상관없음"` 1개만 전달되는 요청이 DTO 검증에서 막히지 않도록 수정하였습니다.

### 2. 선호 동물상 선택 정책 분리

- 일반 동물상 선택 시 정확히 3개만 허용하도록 서비스 로직에서 검증합니다.
- `상관없음` 선택 시 `"상관없음"` 1개만 허용하도록 처리합니다.
- `상관없음`과 일반 동물상이 함께 전달되는 잘못된 요청은 예외 처리하도록 하였습니다.

---

## 기대 효과

- 사용자가 `상관없음`을 선택해도 온보딩 제출이 정상 처리됩니다.
- DTO 유효성 검증과 서비스 비즈니스 로직 간 충돌을 해결할 수 있습니다.
- 선호 동물상 선택 정책을 서비스 계층에서 일관되게 관리할 수 있습니다.