### PR TITLE
[FIX] 설문 완료 사용자 로그인 응답 처리 수정

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/user/service/AuthService.java
+++ b/src/main/java/com/likelion/zooting/domain/user/service/AuthService.java
@@ -33,10 +33,6 @@ public class AuthService {
             throw new GeneralException(UserErrorCode.PIN_MISMATCH);
         }
 
-        if (isSurveyCompleted(user.getStatus())) {
-            throw new GeneralException(UserErrorCode.ALREADY_COMPLETED);
-        }
-
         String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
         return authMapper.toAuthResponse(user, accessToken);
     }


### PR DESCRIPTION
## 연관된 이슈
- #56

---

## 작업 내용
설문 완료 사용자가 다시 로그인할 때 409 Conflict 에러가 발생하던 로직을 수정하였습니다.

기존에는 로그인 시 사용자의 설문 완료 상태를 확인한 뒤, 이미 완료한 사용자라면 `ALREADY_COMPLETED` 예외를 발생시켰습니다.  
하지만 프론트엔드 요구사항에 따라 설문 완료 사용자도 로그인 자체는 정상 처리되어야 하므로, 해당 조건문을 제거하고 200 OK 응답이 반환되도록 수정하였습니다.

### 1. 설문 완료 상태 예외 처리 제거

- 기존 `loginExistingUser()` 메서드에서 설문 완료 여부를 확인하던 조건문을 제거하였습니다.
- `isSurveyCompleted(user.getStatus())` 결과에 따라 `ALREADY_COMPLETED` 예외를 발생시키지 않도록 수정하였습니다.

### 2. 로그인 성공 응답 유지

- PIN 검증에 성공하면 사용자 상태와 관계없이 accessToken을 발급합니다.
- 기존 `AuthResponse` 반환 흐름은 유지하였습니다.
- 설문 완료 사용자도 정상 로그인 응답을 받을 수 있도록 처리하였습니다.

---

## 기대 효과

- 설문 완료 사용자가 재로그인할 때 409 에러가 발생하지 않습니다.
- 프론트엔드에서 로그인 API 응답을 200 OK 기준으로 일관되게 처리할 수 있습니다.
- 로그인 API는 인증 성공 여부만 판단하고, 설문 완료 여부에 따른 화면 분기는 클라이언트에서 처리할 수 있습니다.