### PR TITLE
[FIX] 매칭 결과 조회 API CORS 허용 경로 추가

### DIFF
--- a/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/zooting/infra/security/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                                 "/actuator/health",
                                 "/actuator/prometheus",
                                 "/api/onboarding/instagram",
-                                "/api/internal/**"
+                                "/api/internal/**",
+                                "/api/match/result"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 연관된 이슈
- #58

---

## 작업 내용
프론트엔드에서 매칭 결과 조회 API(`/api/match/result`) 호출 시 CORS 정책에 의해 요청이 차단되지 않도록, 해당 경로를 CORS 허용 설정에 추가하였습니다.

### 1. 매칭 결과 조회 API CORS 허용
- `/api/match/result` 경로를 CORS 허용 대상에 추가하였습니다.
- 프론트엔드 배포 환경에서 해당 API 요청이 정상적으로 전달될 수 있도록 수정하였습니다.

---

## 기대 효과
- 프론트엔드에서 매칭 결과 조회 API 호출 시 CORS 오류를 방지할 수 있습니다.
- 사용자가 매칭 결과를 정상적으로 조회할 수 있습니다.