### PR TITLE
[FIX] 매칭 결과 조회 API dev 브랜치 누락 복구

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultController.java
+++ b/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultController.java
@@ -1,0 +1,27 @@
+package com.likelion.zooting.domain.match.controller;
+
+import com.likelion.zooting.domain.match.dto.MatchResultRequest;
+import com.likelion.zooting.domain.match.dto.MatchResultResponse;
+import com.likelion.zooting.domain.match.service.MatchResultService;
+import com.likelion.zooting.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/match")
+@RequiredArgsConstructor
+public class MatchResultController {
+
+    private final MatchResultService matchResultService;
+
+    @PostMapping("/result")
+    public ResponseEntity<ApiResponse<MatchResultResponse>> getMatchResult(
+            @Valid @RequestBody MatchResultRequest request
+    ) {
+        MatchResultResponse response = matchResultService.getMatchResult(request);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultControllerDocs.java
+++ b/src/main/java/com/likelion/zooting/domain/match/controller/MatchResultControllerDocs.java
@@ -1,0 +1,30 @@
+package com.likelion.zooting.domain.match.controller;
+
+import com.likelion.zooting.domain.match.dto.MatchResultRequest;
+import com.likelion.zooting.domain.match.dto.MatchResultResponse;
+import com.likelion.zooting.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Match", description = "매칭 관련 API")
+public interface MatchResultControllerDocs {
+
+    @Operation(
+            summary = "매칭 결과 확인 API",
+            description = """
+                    사용자가 입력한 인스타 ID와 본인확인용 4자리 숫자를 검증한 후,
+                    18시 이후 매칭 결과를 조회합니다.
+                    
+                    - Request Body로 instagramId, verificationPin을 전달합니다.
+                    - 18시 이전에는 매칭 결과를 조회할 수 없습니다.
+                    - 매칭 성공 시 상대방 인스타 ID를 반환합니다.
+                    - 매칭된 사용자가 없을 경우 isMatched=false를 반환합니다.
+                    """
+    )
+    ResponseEntity<ApiResponse<MatchResultResponse>> getMatchResult(
+            @Valid @RequestBody MatchResultRequest request
+    );
+}

--- a/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultRequest.java
+++ b/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultRequest.java
@@ -1,0 +1,15 @@
+package com.likelion.zooting.domain.match.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record MatchResultRequest(
+
+        @NotBlank(message = "인스타 ID는 필수입니다.")
+        String instagramId,
+
+        @NotBlank(message = "본인확인용 숫자는 필수입니다.")
+        @Pattern(regexp = "\\d{4}", message = "본인확인용 숫자는 숫자 4자리여야 합니다.")
+        String verificationPin
+) {
+}

--- a/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultResponse.java
+++ b/src/main/java/com/likelion/zooting/domain/match/dto/MatchResultResponse.java
@@ -1,0 +1,18 @@
+package com.likelion.zooting.domain.match.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MatchResultResponse(
+        boolean isMatched,
+        String partnerInstagramId
+) {
+
+    public static MatchResultResponse matched(String partnerInstagramId) {
+        return new MatchResultResponse(true, partnerInstagramId);
+    }
+
+    public static MatchResultResponse notMatched() {
+        return new MatchResultResponse(false, null);
+    }
+}

--- a/src/main/java/com/likelion/zooting/domain/match/exception/MatchErrorCode.java
+++ b/src/main/java/com/likelion/zooting/domain/match/exception/MatchErrorCode.java
@@ -16,6 +16,8 @@ public enum MatchErrorCode implements BaseErrorCode {
     NO_MATCHED_USER_CANDIDATES("MATCH_4041", "매칭 대상 사용자가 없습니다.", HttpStatus.NOT_FOUND),
 
     DUPLICATE_EXECUTION_OF_MATCH_SAVE("MATCH_4091", "이미 매칭 결과가 저장되어 있습니다.", HttpStatus.CONFLICT),
+
+    MATCH_RESULT_NOT_FOUND("MATCH_4041", "매칭 결과를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String code;

--- a/src/main/java/com/likelion/zooting/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/match/repository/MatchRepository.java
@@ -4,9 +4,24 @@ import com.likelion.zooting.domain.match.entity.Matches;
 import com.likelion.zooting.domain.user.entity.Gender;
 import com.likelion.zooting.domain.user.entity.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-@Repository
+import java.util.Optional;
+
 public interface MatchRepository extends JpaRepository<Matches, Long> {
+
     boolean existsByMaleUser_GenderAndMaleUser_Status(Gender gender, Status status);
+
+    // 사용자 ID가 남성/여성 사용자 중 하나로 포함된 매칭 결과를 조회한다.
+    // 상대방 User까지 함께 로딩하여 partnerInstagramId 조회 시 추가 쿼리를 줄인다.
+    @Query("""
+        select m
+        from Matches m
+        join fetch m.maleUser
+        join fetch m.femaleUser
+        where m.maleUser.userId = :userId
+           or m.femaleUser.userId = :userId
+    """)
+    Optional<Matches> findByUserIdWithUsers(@Param("userId") Long userId);
 }

--- a/src/main/java/com/likelion/zooting/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/likelion/zooting/domain/match/repository/MatchRepository.java
@@ -6,9 +6,11 @@ import com.likelion.zooting.domain.user.entity.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface MatchRepository extends JpaRepository<Matches, Long> {
 
     boolean existsByMaleUser_GenderAndMaleUser_Status(Gender gender, Status status);

--- a/src/main/java/com/likelion/zooting/domain/match/service/MatchResultService.java
+++ b/src/main/java/com/likelion/zooting/domain/match/service/MatchResultService.java
@@ -1,0 +1,74 @@
+package com.likelion.zooting.domain.match.service;
+
+import com.likelion.zooting.domain.match.dto.MatchResultRequest;
+import com.likelion.zooting.domain.match.dto.MatchResultResponse;
+import com.likelion.zooting.domain.match.entity.Matches;
+import com.likelion.zooting.domain.match.exception.MatchErrorCode;
+import com.likelion.zooting.domain.match.repository.MatchRepository;
+import com.likelion.zooting.domain.user.entity.User;
+import com.likelion.zooting.domain.user.exception.UserErrorCode;
+import com.likelion.zooting.domain.user.repository.UserRepository;
+import com.likelion.zooting.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchResultService {
+
+    private static final LocalTime MATCH_RESULT_OPEN_TIME = LocalTime.of(18, 0);
+    private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private final UserRepository userRepository;
+    private final MatchRepository matchRepository;
+
+    public MatchResultResponse getMatchResult(MatchResultRequest request) {
+        validateAfterOpenTime();
+
+        User user = userRepository.findByInstagramId(request.instagramId())
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        validateVerificationPin(user, request.verificationPin());
+
+        return matchRepository.findByUserIdWithUsers(user.getUserId())
+                .map(matches -> {
+                    User partner = findPartnerUser(matches, user.getUserId());
+                    return MatchResultResponse.matched(partner.getInstagramId());
+                })
+                .orElseGet(MatchResultResponse::notMatched);
+    }
+
+    // 현재 사용자가 포함된 매칭 결과에서 상대방 사용자를 찾는다.
+    private User findPartnerUser(Matches matches, Long userId) {
+        if (matches.getMaleUser().getUserId().equals(userId)) {
+            return matches.getFemaleUser();
+        }
+
+        if (matches.getFemaleUser().getUserId().equals(userId)) {
+            return matches.getMaleUser();
+        }
+
+        throw new GeneralException(MatchErrorCode.MATCH_RESULT_NOT_FOUND);
+    }
+
+    // 매칭 결과는 18시 이후에만 조회할 수 있다.
+    private void validateAfterOpenTime() {
+        LocalTime now = LocalTime.now(KOREA_ZONE_ID);
+
+        if (now.isBefore(MATCH_RESULT_OPEN_TIME)) {
+            throw new GeneralException(MatchErrorCode.MATCH_TIME_FORBIDDEN);
+        }
+    }
+
+    // 사용자가 입력한 본인확인용 숫자가 DB에 저장된 값과 일치하는지 검증한다.
+    private void validateVerificationPin(User user, String verificationPin) {
+        if (!user.getUserPw().equals(verificationPin)) {
+            throw new GeneralException(UserErrorCode.PIN_MISMATCH);
+        }
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
- #60
---

## 작업 내용
매칭 결과 조회 API가 기존 PR에서 merge된 것으로 확인되었으나, 실제 dev 브랜치에는 관련 코드가 정상 반영되지 않아 `/api/match/result` 요청을 처리하지 못하는 문제가 발생하였습니다.

이에 따라 누락된 매칭 결과 조회 API 관련 코드를 다시 작성하여 dev 브랜치에 반영하였습니다.

### 1. 매칭 결과 조회 API 재구현
- `/api/match/result` 엔드포인트를 다시 추가하였습니다.
- 인증된 사용자의 매칭 결과를 조회할 수 있도록 API 흐름을 복구하였습니다.
- 프론트엔드에서 매칭 결과 조회 요청 시 정상 응답을 받을 수 있도록 수정하였습니다.

### 2. 매칭 결과 응답 로직 복구
- 매칭 결과 조회에 필요한 서비스 로직을 다시 작성하였습니다.
- 매칭 결과 응답 DTO를 통해 클라이언트에 필요한 데이터를 반환하도록 구성하였습니다.

### 3. 예외 처리 복구
- 매칭 결과가 없는 경우에 대한 예외 처리를 반영하였습니다.
- 매칭 결과 조회 가능 조건에 맞지 않는 경우 적절한 에러 응답을 반환하도록 처리하였습니다.

---

## 기대 효과
- dev 브랜치 기준으로 매칭 결과 조회 API가 정상 동작합니다.
- 프론트엔드에서 `/api/match/result` 호출 시 API 매핑 누락으로 인한 오류를 방지할 수 있습니다.
- 배포 환경에서도 매칭 결과 조회 기능을 사용할 수 있습니다.
