### PR TITLE
fix(match): 자정 이후 매칭 결과 조회 제한 로직 수정

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/match/service/MatchResultService.java
+++ b/src/main/java/com/likelion/zooting/domain/match/service/MatchResultService.java
@@ -22,13 +22,14 @@ import java.time.ZoneId;
 public class MatchResultService {
 
     private static final LocalTime MATCH_RESULT_OPEN_TIME = LocalTime.of(18, 0);
+    private static final LocalTime NEXT_DAY_RESET_TIME = LocalTime.of(10, 0);
     private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final UserRepository userRepository;
     private final MatchRepository matchRepository;
 
     public MatchResultResponse getMatchResult(MatchResultRequest request) {
-        validateAfterOpenTime();
+        validateResultViewTime();
 
         User user = userRepository.findByInstagramId(request.instagramId())
                 .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
@@ -56,11 +57,14 @@ public class MatchResultService {
         throw new GeneralException(MatchErrorCode.MATCH_RESULT_NOT_FOUND);
     }
 
-    // 매칭 결과는 18시 이후에만 조회할 수 있다.
-    private void validateAfterOpenTime() {
+    // 매칭 결과는 18시 이후부터 다음날 초기화 전까지 조회할 수 있다.
+    private void validateResultViewTime() {
         LocalTime now = LocalTime.now(KOREA_ZONE_ID);
 
-        if (now.isBefore(MATCH_RESULT_OPEN_TIME)) {
+        boolean isAfterOpenTime = !now.isBefore(MATCH_RESULT_OPEN_TIME);
+        boolean isBeforeResetTime = now.isBefore(NEXT_DAY_RESET_TIME);
+
+        if (!isAfterOpenTime && !isBeforeResetTime) {
             throw new GeneralException(MatchErrorCode.MATCH_TIME_FORBIDDEN);
         }
     }


### PR DESCRIPTION
## 연관된 이슈
- #62
---

## 작업 내용
매칭 결과 조회 API에서 자정 이후 매칭 결과 조회가 403으로 차단되는 문제를 수정하였습니다.

기존에는 현재 시간이 18시 이전인지 여부만 검증하고 있어, 18시 이후에는 정상 조회되지만 00시가 지나면 다시 18시 이전으로 판단되어 조회가 제한되는 문제가 있었습니다.

서비스 정책상 매칭 결과는 18시 이후부터 다음날 초기화 전까지 조회 가능해야 하므로, 조회 가능 시간 검증 로직을 수정하였습니다.

### 1. 매칭 결과 조회 가능 시간 검증 로직 수정

- 기존 `validateAfterOpenTime()` 메서드를 `validateResultViewTime()`으로 변경하였습니다.
- 단순히 18시 이후인지 확인하던 방식에서, 아래 조건 중 하나를 만족하면 조회 가능하도록 수정하였습니다.
  - 당일 18시 이후
  - 다음날 초기화 시간 이전

### 2. 자정 이후 조회 제한 문제 해결

- 기존 로직에서는 00시 이후 시간이 다시 18시 이전으로 판단되어 403 에러가 발생했습니다.
- 수정 후에는 자정 이후에도 다음날 초기화 전까지 매칭 결과를 정상 조회할 수 있습니다.

---

## 기대 효과

- 사용자가 18시 이후부터 다음날 초기화 전까지 매칭 결과를 안정적으로 조회할 수 있습니다.
- 실제 서비스 운영 정책과 API 동작이 일치합니다.
- 자정 이후 불필요하게 403 에러가 발생하던 문제를 방지할 수 있습니다.