### PR TITLE
[FIX] 선호 동물상 상관없음 처리 및 동물상 코드 매핑 수정

### DIFF
--- a/src/main/java/com/likelion/zooting/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/likelion/zooting/domain/onboarding/service/OnboardingService.java
@@ -78,10 +78,13 @@ public class OnboardingService {
     boolean isIndifferent = preferredList.size() == 1 && "상관없음".equals(preferredList.get(0));
 
     if (isIndifferent) {
-      // 성별에 따른 모든 가능한 동물상 조회 (COMMON + 사용자 성별 전용)
-      // 예: MALE일 경우 COMMON(강아지, 고양이, 햄스터) + MALE(곰, 원숭이, 공룡)
+      // 상대 성별에 따른 모든 가능한 동물상 조회
+      // 예: MALE 사용자가 상관없음을 선택하면 COMMON + FEMALE 동물상을 선호 동물상으로 저장
+      // 예: FEMALE 사용자가 상관없음을 선택하면 COMMON + MALE 동물상을 선호 동물상으로 저장
+      Scope targetScope = gender == Gender.MALE ? Scope.FEMALE : Scope.MALE;
+
       List<AnimalType> allPossibleAnimals = animalTypeRepository.findByScopeIn(
-              List.of(Scope.COMMON, Scope.valueOf(user.getGender().name()))
+              List.of(Scope.COMMON, targetScope)
       );
 
       for (AnimalType animalType : allPossibleAnimals) {

--- a/src/main/java/com/likelion/zooting/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/likelion/zooting/domain/profile/service/ProfileService.java
@@ -71,7 +71,7 @@ public class ProfileService {
       case "고양이" -> "cat";
       case "곰" -> "bear";
       case "공룡" -> "dinosaur";
-      case "원숭이" -> "monkey";
+      case "여우" -> "fox";
       case "햄스터" -> "hamster";
       case "사슴" -> "deer";
       case "병아리" -> "chick";


### PR DESCRIPTION
## 연관된 이슈
- #66

---

## 작업 내용
온보딩 최종 제출 과정에서 선호 동물상으로 `상관없음`을 선택했을 때, 본인 성별이 아닌 상대 성별 기준의 동물상이 저장되도록 수정했습니다.

또한 프로필/매칭 결과 응답에서 사용하는 동물상 코드 변환 로직에 누락된 동물상 매핑을 추가했습니다.

### 1. `상관없음` 선택 시 Scope 기준 수정
기존에는 사용자의 성별을 그대로 Scope로 변환하여 `COMMON + 본인 성별` 동물상이 저장되고 있었습니다.

이를 수정하여 사용자의 성별과 반대되는 Scope를 계산한 뒤, `COMMON + 상대 성별` 동물상이 저장되도록 변경했습니다.

- 남성 사용자: `COMMON + FEMALE`
- 여성 사용자: `COMMON + MALE`

### 2. 일반 선호 동물상 선택 로직 유지
선호 동물상을 직접 3개 선택한 경우에는 기존과 동일하게 선택한 동물상만 저장되도록 유지했습니다.

### 3. 동물상 코드 변환 매핑 추가
프로필/매칭 결과 응답에서 동물상 이름을 프론트엔드에서 사용하는 코드 값으로 변환할 수 있도록 누락된 매핑을 추가했습니다.

추가 및 정리된 매핑은 다음과 같습니다.

- `토끼` → `rabbit`
- `강아지` → `dog`
- `고양이` → `cat`
- `곰` → `bear`
- `공룡` → `dinosaur`
- `원숭이` → `monkey`
- `햄스터` → `hamster`
- `사슴` → `deer`
- `병아리` → `chick`

---

## 기대 효과
- `상관없음` 선택 시 실제 매칭 대상 성별의 모든 동물상이 선호 조건으로 반영됩니다.
- 선호 동물상 기반 매칭 결과의 정확성을 높일 수 있습니다.
- 본인 성별 동물상이 잘못 선호 조건으로 저장되는 문제를 방지합니다.
- 프론트엔드에서 동물상 이미지/아이콘 렌더링에 필요한 코드 값을 안정적으로 받을 수 있습니다.
- 누락된 동물상 코드로 인해 응답 처리나 화면 표시가 어긋나는 문제를 방지할 수 있습니다.
